### PR TITLE
fix(@ciscospark/plugin-conversation): include fileSize body

### DIFF
--- a/src/client/services/conversation/share-activity/share-activity-base.js
+++ b/src/client/services/conversation/share-activity/share-activity-base.js
@@ -175,7 +175,9 @@ var ShareActivityBase = SparkBase.extend(
           },
           phases: {
             initialize: {
-              fileSize: fileSize
+              body: {
+                fileSize: fileSize
+              }
             },
             upload: {
               $uri: function $uri(session) {

--- a/src/client/services/conversation/share-activity/share-activity-base.js
+++ b/src/client/services/conversation/share-activity/share-activity-base.js
@@ -189,7 +189,7 @@ var ShareActivityBase = SparkBase.extend(
                 return session.finishUploadUrl;
               },
               body: {
-                fileSize: fileSize
+                size: fileSize
               }
             }
           }


### PR DESCRIPTION
The fileSize field for content upload was not being included in the json payload for the files `upload_session` endpoint, since it was not wrapped in a body dict that the request http framework understands.

Also renamed 'fileSize' for the complete upload flow '/upload_session/finish' to 'size' to align with the rest of the Spark clients.