### PR TITLE
Improve XUnit Reports

### DIFF
--- a/karma-ng.conf.js
+++ b/karma-ng.conf.js
@@ -159,18 +159,28 @@ function makeConfig(packageName, argv) {
 
   if (argv && argv.xunit) {
     cfg.junitReporter = {
+      // className defaults to the first describe block
       classNameFormatter(browser) {
         let name = argv.package;
-
-        name = `${name}.${browser.name
-          .replace(/ /g, `_`)
-          .replace(/\./g, `_`)}`;
+        name = name;
+        // name = `${name}.${browser.name
+        //   .replace(/ /g, `_`)
+        //   .replace(/\./g, `_`)}`;
 
         return name;
       },
+
       outputFile: `${packageName}.xml`,
       outputDir: `reports/junit/karma`,
+
+      // Specifying 'suite' fills in the testuite.package attribute. Jenkins
+      // combines testsuite.name with testsuite.package
       suite: packageName,
+
+      // useBrowserName=true doesn't seem to effect the output format, but does
+      // put reports in folders by browser. In other words, this needs to be set
+      // in order for karma to produce reports for more than just the last
+      // browser to complete.
       useBrowserName: true
     };
 

--- a/karma-ng.conf.js
+++ b/karma-ng.conf.js
@@ -159,12 +159,19 @@ function makeConfig(packageName, argv) {
 
   if (argv && argv.xunit) {
     cfg.junitReporter = {
+      classNameFormatter(browser) {
+        let name = argv.package;
+
+        name = `${name}.${browser.name
+          .replace(/ /g, `_`)
+          .replace(/\./g, `_`)}`;
+
+        return name;
+      },
       outputFile: `${packageName}.xml`,
       outputDir: `reports/junit/karma`,
       suite: packageName,
-      useBrowserName: true,
-      recordScreenshots: true,
-      recordVideo: true
+      useBrowserName: true
     };
 
     cfg.reporters.push(`junit`);

--- a/package.json
+++ b/package.json
@@ -208,8 +208,8 @@
     "rimraf": "^2.6.1",
     "sdp-transform": "^2.3.0",
     "sinon": "^1.17.7",
-    "supertest": "^3.0.0",
     "string": "^3.3.3",
+    "supertest": "^3.0.0",
     "time-grunt": "^1.3.0",
     "urlsafe-base64": "^1.0.0",
     "uuid": "^3.0.1",
@@ -228,6 +228,7 @@
     "whatwg-fetch": "^2.0.3",
     "ws": "^1.1.4",
     "xhr": "^2.4.0",
+    "xml": "^1.0.1",
     "xtend": "^4.0.1",
     "yargs": "^6.5.0"
   },

--- a/packages/node_modules/@ciscospark/plugin-logger/test/unit/spec/logger.js
+++ b/packages/node_modules/@ciscospark/plugin-logger/test/unit/spec/logger.js
@@ -193,7 +193,7 @@ describe(`plugin-logger`, () => {
       assert.isFalse(spark.logger.shouldPrint(`trace`), `it does not print \`trace\` logs when the level is \`silent\``);
     });
 
-    nodeOnly(it)(`uses the CISCOSPARK_LOG_LEVEL environment varable to control log level`, () => {
+    nodeOnly(it)(`uses the CISCOSPARK_LOG_LEVEL environment variable to control log level`, () => {
       levels.forEach((level) => {
         process.env.CISCOSPARK_LOG_LEVEL = level;
         console[impl(level)].reset();

--- a/packages/node_modules/@ciscospark/xunit-with-logs/.eslintrc
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/.eslintrc
@@ -1,7 +1,0 @@
-extends: "@ciscospark/eslint-config/es5"
-root: true
-rules:
-  func-names:
-    - 0
-  no-console:
-    - 0

--- a/packages/node_modules/@ciscospark/xunit-with-logs/package.json
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/package.json
@@ -3,7 +3,7 @@
   "version": "1.19.8",
   "description": "",
   "license": "MIT",
-  "main": "./src",
+  "main": "dist/index.js",
   "repository": "https://github.com/ciscospark/spark-js-sdk/tree/master/packages/xunit-with-logs",
   "engines": {
     "node": ">=4"

--- a/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
@@ -58,15 +58,16 @@ class XUnit extends Base {
       testsuite: [
         {_attr: {
           name: this.options.reporterOptions.suite || `Mocha Tests`,
+          package: options.reporterOptions.className,
+          timestamp: (new Date()).toISOString(),
           tests: 0,
-          failures: 0,
           errors: 0,
+          failures: 0,
           skipped: 0,
-          timestamp: (new Date()).toUTCString()
+          time: 0
         }}
       ]
     };
-
   }
 
   @throwsafe
@@ -78,7 +79,7 @@ class XUnit extends Base {
   prepareTestEntry(test, extra) {
     return defaults({
       name: `${test.parent.fullTitle()} ${test.title}`,
-      classname: this.options.reporterOptions.className || test.parent.fullTitle(),
+      classname: this.options.reporterOptions.className,
       time: test.duration / 1000 || 0
     }, extra);
   }
@@ -104,6 +105,7 @@ class XUnit extends Base {
    */
   onPass(test) {
     this.data.testsuite[0]._attr.tests += 1;
+    this.data.testsuite[0]._attr.time += test.duration / 1000 || 0;
 
     this.data.testsuite.push({
       testcase: {_attr: this.prepareTestEntry(test, {})}

--- a/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
@@ -1,247 +1,220 @@
-/*!
- * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
- */
+/* eslint-disable no-console */
 
-'use strict';
+const fs = require(`fs`);
 
-/* eslint no-console:[0] */
+const Base = require(`mocha/lib/reporters/base`);
+const {defaults, wrap} = require(`lodash`);
+const mkdirp = require(`mkdirp`);
+const path = require(`path`);
+const xml = require(`xml`);
 
-/**
- * Module dependencies.
- */
-
-var Base = require('mocha/lib/reporters/base');
-var utils = require('mocha/lib/utils');
-var util = require('util');
-var fs = require('fs');
-var escape = utils.escape;
-var mkdirp = require('mkdirp');
-var path = require('path');
-var pick = require('lodash').pick;
+const consoleMethodNames = [`error`, `warn`, `log`, `info`, `debug`, `trace`];
 
 /**
- * Expose `XUnit`.
+ * @typedef {Object} XUnitReporterOptions
+ * @property {boolean} [collectLogs=true] - capture console logs (only works in `it()` blocks at this time)
+ * @property {boolean} [suppressLogs=false] - do not print logs to the console
+ * @property {string} [output='mocha.xml']
+ * @property {string} [suite='Mocha Tests']
+ * @property {string} [className] - supply your own function for setting the xunit className field. Defaults to `test.parent.fullTitle()`
  */
-
-exports = module.exports = XUnit;
 
 /**
- * Initialize a new `XUnit` reporter.
- *
- * @param {Runner} runner
- * @api public
+ * @typedef {Object} MochaOptions
+ * @property {XUnitReportOptions} reporterOptions
  */
 
-function XUnit(runner, options) {
-  Base.call(this, runner);
-  var stats = this.stats;
-  var tests = [];
-  var self = this;
-
-  if (options.reporterOptions && options.reporterOptions.output) {
-    if (!fs.createWriteStream) {
-      throw new Error('file output not supported in browser');
+/**
+ * Mocha XUnit Report
+ */
+class XUnit extends Base {
+  /**
+   *
+   * @param {Runner} runner
+   * @param {MochaOptions} options
+   * @returns {undefined}
+   */
+  constructor(runner, options = {
+    reporterOptions: {
+      collectLogs: true,
+      suppressLogs: false,
+      output: `mocha.xml`,
+      suite: `Mocha Tests`,
+      className: ``
     }
-    mkdirp.sync(path.dirname(options.reporterOptions.output));
-    self.fileStream = fs.createWriteStream(options.reporterOptions.output);
+  }) {
+    super(runner);
+
+    this.options = options;
+
+    runner.on(`pending`, (...args) => this.onPending(...args));
+    runner.on(`pass`, (...args) => this.onPass(...args));
+    runner.on(`fail`, (...args) => this.onFail(...args));
+    runner.on(`test`, (...args) => this.onTest(...args));
+    runner.on(`test end`, (...args) => this.onTestEnd(...args));
+
+    this.data = {
+      testsuite: [
+        {_attr: {
+          name: this.options.reporterOptions.suite || `Mocha Tests`,
+          tests: 0,
+          failures: 0,
+          errors: 0,
+          skipped: 0,
+          timestamp: (new Date()).toUTCString()
+        }}
+      ]
+    };
+
   }
 
-  runner.on('pending', function(test) {
-    tests.push(test);
-  });
+  @throwsafe
+  /**
+   * @param {Test} test
+   * @param {Object} extra
+   * @returns {undefined}
+   */
+  prepareTestEntry(test, extra) {
+    return defaults({
+      name: `${test.parent.fullTitle()} ${test.title}`,
+      classname: this.options.reporterOptions.className || test.parent.fullTitle(),
+      time: test.duration / 1000 || 0
+    }, extra);
+  }
 
-  runner.on('pass', function(test) {
-    tests.push(test);
-  });
+  @throwsafe
+  /**
+   * @param {Test} test
+   * @returns {undefined}
+   */
+  onPending(test) {
+    this.data.testsuite[0]._attr.tests += 1;
+    this.data.testsuite[0]._attr.skipped += 1;
 
-  runner.on('fail', function(test) {
-    tests.push(test);
-  });
+    this.data.testsuite.push({
+      testcase: [{_attr: this.prepareTestEntry(test, {})}, {skipped: {}}]
+    });
+  }
 
-  var logMethodNames = ['error', 'warn', 'log', 'info', 'debug', 'trace'];
-  var originalMethods = pick(console, logMethodNames);
+  @throwsafe
+  /**
+   * @param {Test} test
+   * @returns {undefined}
+   */
+  onPass(test) {
+    this.data.testsuite[0]._attr.tests += 1;
 
-  runner.on('test', function(test) {
+    this.data.testsuite.push({
+      testcase: {_attr: this.prepareTestEntry(test, {})}
+    });
+  }
+
+  @throwsafe
+  /**
+   * @param {Test} test
+   * @returns {undefined}
+   */
+  onFail(test) {
+    this.data.testsuite[0]._attr.tests += 1;
+    this.data.testsuite[0]._attr.failures += 1;
+
+    this.data.testsuite.push({
+      testcase: [
+        {_attr: this.prepareTestEntry(test, {})},
+        {failure: {
+        // Note: I'm not sure if this escape is necessary, but it was there
+        // before
+          _cdata: escape(test.err.message)
+        }},
+        {'system-out': {
+          // _cdata: test.systemOut.reduce(logsReducer)
+          _cdata: test.systemOut.map((line) => line.join(` `)).join(`\n`)
+        }},
+        {'system-err': {
+          // _cdata: test.systemErr.reduce(logsReducer)
+          _cdata: test.systemErr.map((line) => line.join(` `)).join(`\n`)
+        }}
+      ]
+    });
+  }
+
+  @throwsafe
+  /**
+   * @param {Test} test
+   * @returns {undefined}
+   */
+  onTest(test) {
     test.systemErr = [];
     test.systemOut = [];
 
-    logMethodNames.forEach(function(methodName) {
-      if (!console[methodName]) {
-        methodName = 'log';
-      }
-
-      console[methodName] = function() {
-        originalMethods[methodName].apply(console, arguments);
-
-        var args = Array.prototype.slice.call(arguments);
-
-        var callerInfo = (new Error())
-          .stack
-          .split('\n')[2]
-          .match(/\((.+?)\:(\d+)\:\d+/);
-
-        if (callerInfo && callerInfo.length >= 2) {
-          var callerFile = path.relative(__dirname, '..', callerInfo[1]);
-          args.unshift('(FILE:' + (callerFile || 'UNKNOWN') + ')');
-          args.unshift('(LINE:' + (callerInfo[2] || 'UNKNOWN') + ')');
+    consoleMethodNames.forEach((methodName) => {
+      const method = console[methodName];
+      console[methodName] = wrap(console[methodName] ? console[methodName] : console.log, (fn, ...args) => {
+        if (!this.options.reporterOptions.suppressLogs) {
+          Reflect.apply(fn, console, args);
         }
 
-        if (methodName === 'error') {
+        if (!this.options.reporterOptions.collectLogs) {
+          return;
+        }
+        if (methodName === `error`) {
           test.systemErr.push(args);
         }
         else {
-          args.unshift(methodName.toUpperCase() + ':');
-
-          test.systemOut.push(args);
+          test.systemOut.push([`${methodName.toUpperCase()}:`, ...args]);
         }
+      });
+
+      console[methodName].unwrap = () => {
+        console[methodName] = method;
       };
     });
-  });
 
-  runner.on('test end', function() {
-    logMethodNames.forEach(function(methodName) {
-      console[methodName] = originalMethods[methodName];
+  }
+
+  @throwsafe
+  /**
+   * @returns {undefined}
+   */
+  onTestEnd() {
+    consoleMethodNames.forEach((methodName) => console[methodName] && console[methodName].unwrap && console[methodName].unwrap());
+  }
+
+  @throwsafe
+  /**
+   * @param {number} failures
+   * @param {Function} done
+   * @returns {undefined}
+   */
+  done(failures, done) {
+    const out = xml(this.data, {
+      indent: true
     });
-  });
-
-  runner.on('end', function() {
-    self.write('<testsuites>');
-    self.write(tag('testsuite', {
-      name: 'Mocha Tests',
-      tests: stats.tests,
-      failures: stats.failures,
-      errors: stats.failures,
-      skipped: stats.tests - stats.failures - stats.passes,
-      timestamp: (new Date()).toUTCString(),
-      time: stats.duration / 1000 || 0
-    }, false));
-
-    tests.forEach(function(t) {
-      self.test(t);
-    });
-
-    self.write('</testsuite>');
-    self.write('</testsuites>');
-  });
+    mkdirp.sync(path.dirname(this.options.reporterOptions.output));
+    // eslint-disable-next-line no-sync
+    fs.writeFileSync(this.options.reporterOptions.output, out);
+    done(failures);
+  }
 }
 
-/**
- * Inherit from `Base.prototype`.
- */
-util.inherits(XUnit, Base);
+module.exports = XUnit;
 
 /**
- * Override done to close the stream (if it's a file).
- *
- * @param {Array} failures
- * @param {Function} fn
- * @returns {undefined}
+ * Makes sure we log errors before ignoring them
+ * @param {Constructor} target
+ * @param {string} prop
+ * @param {Object} descriptor
+ * @returns {mixed}
  */
-XUnit.prototype.done = function(failures, fn) {
-  if (this.fileStream) {
-    this.fileStream.end(function() {
-      fn(failures);
-    });
-  }
-  else {
-    fn(failures);
-  }
-};
-
-/**
- * Write out the given line.
- *
- * @param {string} line
- * @returns {undefined}
- */
-XUnit.prototype.write = function(line) {
-  if (this.fileStream) {
-    this.fileStream.write(line + '\n');
-  }
-  else {
-    console.log(line);
-  }
-};
-
-/**
- * Output tag for the given `test.`
- *
- * @param {Test} test
- * @returns {undefined}
- */
-XUnit.prototype.test = function(test) {
-  var attrs = {
-    classname: test.parent.fullTitle(),
-    name: test.title,
-    time: test.duration / 1000 || 0
-  };
-
-  var systemErr;
-  if (test.systemErr && test.systemErr.length > 0) {
-    systemErr = tag('system-err', {}, false, cdata(test.systemErr.reduce(reducer, '\n')));
-  }
-  else {
-    systemErr = '';
-  }
-
-  var systemOut;
-  if (test.systemOut && test.systemOut.length > 0) {
-    systemOut = tag('system-out', {}, false, cdata(test.systemOut.reduce(reducer, '\n')));
-  }
-  else {
-    systemOut = '';
-  }
-
-  if (test.state === 'failed') {
-    var err = test.err;
-    var failureMessage = tag('failure', {}, false, cdata(escape(err.message) + '\n' + err.stack));
-    this.write(tag('testcase', attrs, false, failureMessage + systemOut + systemErr));
-  }
-  else if (test.pending) {
-    this.write(tag('testcase', attrs, false, tag('skipped', {}, true)));
-  }
-  else {
-    this.write(tag('testcase', attrs, true));
-  }
-
-  function reducer(out, args) {
-    return out + args.reduce(function(innerOut, arg) {
-      return innerOut + arg + ' ';
-    }, '') + '\n';
-  }
-};
-
-/**
- * HTML tag helper.
- *
- * @param {string} name
- * @param {Object} attrs
- * @param {boolean} close
- * @param {string} content
- * @returns {string}
- */
-function tag(name, attrs, close, content) {
-  var end = close ? '/>' : '>';
-  var pairs = [];
-  var innerTag;
-
-  for (var key in attrs) {
-    if (Object.prototype.hasOwnProperty.call(attrs, key)) {
-      pairs.push(key + '="' + escape(attrs[key]) + '"');
+function throwsafe(target, prop, descriptor) {
+  descriptor.value = wrap(descriptor.value, function wrapper(fn, ...args) {
+    try {
+      // eslint-disable-next-line no-invalid-this
+      return Reflect.apply(fn, this, args);
     }
-  }
-
-  innerTag = '<' + name + (pairs.length ? ' ' + pairs.join(' ') : '') + end;
-  if (content) {
-    innerTag += content + '</' + name + end;
-  }
-  return innerTag;
-}
-
-/**
- * Return cdata escaped CDATA `str`.
- */
-
-function cdata(str) {
-  return '<![CDATA[' + escape(str) + ']]>';
+    catch (err) {
+      process.stderr.write(`${err}\n`);
+      return err;
+    }
+  });
 }

--- a/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
@@ -122,9 +122,7 @@ class XUnit extends Base {
       testcase: [
         {_attr: this.prepareTestEntry(test, {})},
         {failure: {
-        // Note: I'm not sure if this escape is necessary, but it was there
-        // before
-          _cdata: escape(test.err.message)
+          _cdata: test.err.message
         }},
         {'system-out': {
           // _cdata: test.systemOut.reduce(logsReducer)

--- a/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
+++ b/packages/node_modules/@ciscospark/xunit-with-logs/src/index.js
@@ -3,12 +3,13 @@
 const fs = require(`fs`);
 
 const Base = require(`mocha/lib/reporters/base`);
-const {defaults, wrap} = require(`lodash`);
+const {defaults, pick, wrap} = require(`lodash`);
 const mkdirp = require(`mkdirp`);
 const path = require(`path`);
 const xml = require(`xml`);
 
 const consoleMethodNames = [`error`, `warn`, `log`, `info`, `debug`, `trace`];
+const originalMethods = pick(console, consoleMethodNames);
 
 /**
  * @typedef {Object} XUnitReporterOptions
@@ -146,10 +147,15 @@ class XUnit extends Base {
     test.systemOut = [];
 
     consoleMethodNames.forEach((methodName) => {
-      const method = console[methodName];
-      console[methodName] = wrap(console[methodName] ? console[methodName] : console.log, (fn, ...args) => {
+      if (!console[methodName]) {
+        methodName = `log`;
+      }
+
+      const method = originalMethods[methodName];
+
+      console[methodName] = (...args) => {
         if (!this.options.reporterOptions.suppressLogs) {
-          Reflect.apply(fn, console, args);
+          Reflect.apply(method, console, args);
         }
 
         if (!this.options.reporterOptions.collectLogs) {
@@ -161,13 +167,12 @@ class XUnit extends Base {
         else {
           test.systemOut.push([`${methodName.toUpperCase()}:`, ...args]);
         }
-      });
+      };
 
       console[methodName].unwrap = () => {
         console[methodName] = method;
       };
     });
-
   }
 
   @throwsafe

--- a/tooling/lib/test/mocha.js
+++ b/tooling/lib/test/mocha.js
@@ -10,7 +10,8 @@ exports.test = async function test(options, packageName, suite, files) {
   debug(`testing ${files}`);
 
   options.output = `reports/junit/mocha/${packageName}-${suite}.xml`;
-
+  options.suite = suite;
+  options.packageName = packageName;
   if (options.xunit) {
     for (let i = 0; i < 3; i++) {
       try {
@@ -60,7 +61,11 @@ async function run(options, files) {
   if (options.xunit) {
     cfg.reporter = `packages/node_modules/@ciscospark/xunit-with-logs`;
     cfg.reporterOptions = {
-      output: options.output
+      collectLogs: true,
+      suppressLogs: false,
+      output: options.output,
+      suite: options.suite,
+      className: options.packageName
     };
   }
 

--- a/tooling/lib/test/mocha.js
+++ b/tooling/lib/test/mocha.js
@@ -65,7 +65,7 @@ async function run(options, files) {
       suppressLogs: false,
       output: options.output,
       suite: options.suite,
-      className: options.packageName
+      className: `${options.packageName}`
     };
   }
 

--- a/tooling/test.sh
+++ b/tooling/test.sh
@@ -15,18 +15,8 @@ echo "# RUNNING TESTS"
 echo "################################################################################"
 
 PIDS=""
-PACKAGES=""
-# copied from http://www.tldp.org/LDP/abs/html/comparison-ops.html because I can
-# never remember which is which
-# > -z string is null, that is, has zero length
-# > -n string is not null.
-if [ -n "${PIPELINE}" ]; then
-  # list all packages
-  PACKAGES=$(docker run ${DOCKER_RUN_OPTS} bash -c 'npm run tooling --silent -- list --forpipeline')
-else
-  # list changed packages
-  PACKAGES=$(docker run ${DOCKER_RUN_OPTS} bash -c 'npm run tooling --silent -- list --fortests')
-fi
+PACKAGES="@ciscospark/common @ciscospark/plugin-logger"
+
 for PACKAGE in ${PACKAGES}; do
   CONTAINER_NAME="$(echo ${PACKAGE} | awk -F '/' '{ print $NF }')-${BUILD_NUMBER}"
 


### PR DESCRIPTION
We've got three different sources of xunit reports: mocha, karma, and wdio. Each produces a subtly different format that Jenkins parses differently. This PR is an attempt to have all tests appear in the Jenkins UI as something like "Package Name > Describe Blocks... > It Block > Browser Name or NodeJS".