### PR TITLE
test(@ciscospark/i-p-search): add dynamic debug to /applications call

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-search/test/integration/spec/search.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-search/test/integration/spec/search.js
@@ -35,19 +35,37 @@ describe(`plugin-search`, () => {
 
     before(`create bot`, function() {
       this.timeout(retry.timeout(20000));
-      return retry(() => spark.request({
-        api: `hydra`,
-        resource: `applications`,
-        method: `POST`,
-        body: {
-          name: `Personal Assistant`,
-          botEmail: `${uuid.v4()}@sparkbot.io`,
-          type: `bot`
+
+      const clientIdentifier = String(Date.now()).substr(-4);
+      return spark.request({
+        // return retry(() => spark.request({
+        service: `conversation`,
+        resource: `logToken`,
+        qs: {
+          clientIdentifier
         }
       })
-        .then((results) => {
-          bot = results.body;
-        }));
+        .then((res) => spark.request({
+          api: `hydra`,
+          resource: `applications`,
+          method: `POST`,
+          body: {
+            name: `Personal Assistant`,
+            botEmail: `${uuid.v4()}@sparkbot.io`,
+            type: `bot`
+          },
+          headers: {
+            logLevelToken: res.body.logToken
+          }
+        })
+          .then((results) => {
+            bot = results.body;
+          })
+          .catch((err) => {
+            err.message += `DYNAMIC_DEBUG_IDENTIFIER: ${clientIdentifier}`;
+            throw err;
+          }))
+        ;
     });
 
     after(() => spark && spark.internal.mercury.disconnect());


### PR DESCRIPTION
Dynamic Debug is a feature our native clients use to induce debug-level logs for specific API calls. 

`POST /applications` is kinda buggy in Safari. We want to hit it with dynamic debug to see if can figure out why

Note: this is blocked because logLevelToken is not on the CORS allowed list