### PR TITLE
fix(plugin-people): modify people.list to finish batching when notFou…

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-people/src/people-batcher.js
+++ b/packages/node_modules/@ciscospark/plugin-people/src/people-batcher.js
@@ -18,11 +18,13 @@ const PersonUUIDRequestBatcher = Batcher.extend({
    * @returns {Promise}
    */
   handleHttpSuccess(res) {
-    // combine item and notFoundIds lists
-    const notFounds = res.body.notFoundIds || [];
     return Promise.all(res.body.items.map((personResponse) =>
-      this.handleItemSuccess(personResponse.id, personResponse))
-      .concat(notFounds.map((id) => this.handleItemSuccess(id))));
+      this.handleItemSuccess(personResponse.id, personResponse)))
+      // make sure any notFoundIds are resolved successfully
+      .then((results) => {
+        res.body.notFoundIds.forEach((id) => this.handleItemSuccess(id));
+        return results;
+      });
   },
 
   handleItemFailure(email, response) {

--- a/packages/node_modules/@ciscospark/plugin-people/src/people-batcher.js
+++ b/packages/node_modules/@ciscospark/plugin-people/src/people-batcher.js
@@ -18,8 +18,11 @@ const PersonUUIDRequestBatcher = Batcher.extend({
    * @returns {Promise}
    */
   handleHttpSuccess(res) {
+    // combine item and notFoundIds lists
+    const notFounds = res.body.notFoundIds || [];
     return Promise.all(res.body.items.map((personResponse) =>
-      this.handleItemSuccess(personResponse.id, personResponse)));
+      this.handleItemSuccess(personResponse.id, personResponse))
+      .concat(notFounds.map((id) => this.handleItemSuccess(id))));
   },
 
   handleItemFailure(email, response) {

--- a/packages/node_modules/@ciscospark/plugin-people/src/people.js
+++ b/packages/node_modules/@ciscospark/plugin-people/src/people.js
@@ -154,18 +154,11 @@ const People = SparkPlugin.extend({
     if (Array.isArray(options)) {
       const peopleIds = options;
       return Promise.all(peopleIds.map((personId) => this.batcher.request(personId)))
-        // remove any not found placeholders
-        // expect notFounds to be the vast minority.
-        // batcher appends the not founds results contiguously after all of the founds.
-        .then((results) => {
-          let idx = results.length - 1;
-          while (idx >= 0 && !results[idx]) {
-            idx -= 1;
-          }
-          return (idx >= 0 && results.slice(results.length - idx)) || [];
-        })
-        // return an empty list on errors
-        .catch(() => []);
+        .catch((reason) => {
+          this.logger.warn(`People: list encountered an error "${reason && reason.message || reason}"`);
+          // return an empty list on errors
+          return [];
+        });
     }
     return this.request({
       service: 'hydra',

--- a/packages/node_modules/@ciscospark/plugin-people/src/people.js
+++ b/packages/node_modules/@ciscospark/plugin-people/src/people.js
@@ -67,9 +67,15 @@ const People = SparkPlugin.extend({
 
   /**
    * Returns a list of people
+   * Hydra responds with both found (items) and not found (notFoundIds) Ids. The possible
+   * combinations and Hydra responses are
+   * list([VALID_ID1, VALID_ID2]) -> valid response with 2 users, nothing in notFoundIds
+   * list([VALID_ID1, INVALID_ID2]) -> valid response with 1 user, and INVALID_ID2 in notFoundIds
+   * list([INVALID_ID1, INVALID_ID2]) ->  “One or more of the arguments is invalid” response
+   *
    * @instance
    * @memberof People
-   * @param {Object | uuid[]} options or array of uuids
+   * @param {Object | uuid[]} options or a possibly empty array of uuids
    * @param {email} options.email - Returns people with an email that contains this string
    * @param {string} options.displayName - Returns people with a name that contains this string
    * @param {bool} showAllTypes optional flag that requires Hydra to send every type field,
@@ -147,7 +153,19 @@ const People = SparkPlugin.extend({
   list(options) {
     if (Array.isArray(options)) {
       const peopleIds = options;
-      return Promise.all(peopleIds.map((personId) => this.batcher.request(personId)));
+      return Promise.all(peopleIds.map((personId) => this.batcher.request(personId)))
+        // remove any not found placeholders
+        // expect notFounds to be the vast minority.
+        // batcher appends the not founds results contiguously after all of the founds.
+        .then((results) => {
+          let idx = results.length - 1;
+          while (idx >= 0 && !results[idx]) {
+            idx -= 1;
+          }
+          return (idx >= 0 && results.slice(results.length - idx)) || [];
+        })
+        // return an empty list on errors
+        .catch(() => []);
     }
     return this.request({
       service: 'hydra',

--- a/packages/node_modules/@ciscospark/plugin-people/test/integration/spec/people.js
+++ b/packages/node_modules/@ciscospark/plugin-people/test/integration/spec/people.js
@@ -14,6 +14,7 @@ describe('plugin-people', function () {
   this.timeout(60000);
   describe('People', () => {
     let bones, mccoy, spock;
+    const invalidIds = ['foo', 'bar', 'bang'];
 
     beforeEach('create users', () => testUsers.create({count: 3})
       .then((users) => {
@@ -36,6 +37,9 @@ describe('plugin-people', function () {
           assert.isPerson(peopleResponse);
           assert.equal(peopleResponse.emails[0], mccoy.email);
         }));
+
+      it('gets an unknown person by id', () => spock.spark.people.get(invalidIds[0])
+        .catch((peopleResponse) => assert.match.same(peopleResponse, undefined)));
 
       it('gets the current user with "get(\'me\')"', () => spock.spark.people.get('me')
         .then((peopleResponse) => {
@@ -73,6 +77,33 @@ describe('plugin-people', function () {
           assert.equal(peopleResponse[1].emails[0], spock.email);
         }));
 
+      // list([VALID_ID, VALID_ID]) -> valid response with 2 users, nothing in notFoundIds
+      it('gets a group of found people by ids', () => spock.spark.people.list([mccoy.id, spock.id, bones.id])
+        .then((peopleResponse) => {
+          assert.equal(peopleResponse.length, 3);
+          assert.isPerson(peopleResponse[0]);
+          assert.isPerson(peopleResponse[1]);
+          assert.isPerson(peopleResponse[2]);
+          assert.equal(peopleResponse[0].emails[0], mccoy.email);
+          assert.equal(peopleResponse[1].emails[0], spock.email);
+          assert.equal(peopleResponse[2].emails[0], bones.email);
+        }));
+      // list([VALID_ID, INVALID_ID]) -> valid response with VALID_ID user, and INVALID_ID in notFoundIds
+      it('gets a group of mixed found and not found people by ids', () => spock.spark.people.list([mccoy.id, invalidIds[1], spock.id, bones.id])
+        .then((peopleResponse) => {
+          assert.equal(peopleResponse.length, 3);
+          assert.isPerson(peopleResponse[0]);
+          assert.isPerson(peopleResponse[1]);
+          assert.isPerson(peopleResponse[2]);
+          assert.equal(peopleResponse[0].emails[0], mccoy.email);
+          assert.equal(peopleResponse[1].emails[0], spock.email);
+          assert.equal(peopleResponse[2].emails[0], bones.email);
+        }));
+      // list([INVALID_ID, INVALID_ID]) ->  “One or more of the arguments is invalid” response, empty list
+      it('gets a group of ONLY not found people by ids', () => spock.spark.people.list(invalidIds)
+        .then((peopleResponse) => {
+          assert.equal(peopleResponse.length, 0);
+        }));
       it('defaults to false showAllTypes', () => spock.spark.people.list([mccoy.id, spock.id, bones.id])
         .then(assert.isFalse(spock.spark.people.batcher.config.showAllTypes)));
 

--- a/packages/node_modules/@ciscospark/plugin-people/test/integration/spec/people.js
+++ b/packages/node_modules/@ciscospark/plugin-people/test/integration/spec/people.js
@@ -88,6 +88,7 @@ describe('plugin-people', function () {
           assert.equal(peopleResponse[1].emails[0], spock.email);
           assert.equal(peopleResponse[2].emails[0], bones.email);
         }));
+
       // list([VALID_ID, INVALID_ID]) -> valid response with VALID_ID user, and INVALID_ID in notFoundIds
       it('gets a group of mixed found and not found people by ids', () => spock.spark.people.list([mccoy.id, invalidIds[1], spock.id, bones.id])
         .then((peopleResponse) => {
@@ -99,11 +100,13 @@ describe('plugin-people', function () {
           assert.equal(peopleResponse[1].emails[0], spock.email);
           assert.equal(peopleResponse[2].emails[0], bones.email);
         }));
+
       // list([INVALID_ID, INVALID_ID]) ->  “One or more of the arguments is invalid” response, empty list
       it('gets a group of ONLY not found people by ids', () => spock.spark.people.list(invalidIds)
         .then((peopleResponse) => {
           assert.equal(peopleResponse.length, 0);
         }));
+
       it('defaults to false showAllTypes', () => spock.spark.people.list([mccoy.id, spock.id, bones.id])
         .then(assert.isFalse(spock.spark.people.batcher.config.showAllTypes)));
 


### PR DESCRIPTION
…ndIds exists

The total batched PII requests are equal to the number of returned PIIs (body.items) and the list of missing PIIs (body.notFoundIds). people.list must resolve both items and notFoundIds to complete the batch and ultimately resolve the requested PIIs.
Previously notFoundIds was ignored and the batch always failed with a timeout.

# Pull Request Template

## Description

On HTTP success the people-batcher now calls handleItemSuccess for each element of notFoundIds, allowing batch to fully resolve all requested ids.
People.list returns an empty list when http errors are encounted (bad request when *no* items are returned, even if notFoundIds could have been populted).
Fixes # (issue)
#846 
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Requested a mix of known and unknown ids to test notFoundIds were handled
- [ ] Requested only unknown ids to test no items returned, http request failure

**Test Configuration**:
* SDK Version 
* Node/Browser Version 8.6
* NPM Version 5.7.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
