### PR TITLE
fix(spark-core): emit InvalidRequestError, if refresh token expires

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
@@ -425,6 +425,23 @@ const Credentials = SparkPlugin.extend({
       })
       .then(() => {
         this.scheduleRefresh(this.supertoken.expires);
+      })
+      .catch((error) => {
+        const {InvalidRequestError} = grantErrors;
+        if (error instanceof InvalidRequestError) {
+          // Error: The refresh token provided is expired, revoked, malformed, or invalid. Hence emit an event to the client, an opportunity to logout.
+          this.unset('supertoken');
+          while (this.userTokens.models.length) {
+            try {
+              this.userTokens.remove(this.userTokens.models[0]);
+            }
+            catch (err) {
+              this.logger.warn('credentials: failed to remove user token', err);
+            }
+          }
+          this.spark.trigger('client:InvalidRequestError');
+        }
+        return Promise.reject(error);
       });
   },
 

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
@@ -6,7 +6,7 @@ import {set} from 'lodash';
 import {assert} from '@ciscospark/test-helper-chai';
 import sinon from '@ciscospark/test-helper-sinon';
 import MockSpark from '@ciscospark/test-helper-mock-spark';
-import {Credentials, Token} from '@ciscospark/spark-core';
+import {Credentials, Token, grantErrors} from '@ciscospark/spark-core';
 import {inBrowser} from '@ciscospark/common';
 import lolex from 'lolex';
 
@@ -723,6 +723,48 @@ describe('spark-core', () => {
         credentials.refresh();
         return credentials.getUserToken('scope1')
           .then((result) => assert.deepEqual(result, t2));
+      });
+
+      it('emits InvalidRequestError when the refresh token and access token expire', () => {
+        const spark = new MockSpark();
+        const credentials = new Credentials(undefined, {parent: spark});
+        spark.trigger('change:config');
+        const st = makeToken(spark, {
+          access_token: 'ST',
+          refresh_token: 'RT'
+        });
+
+        const t1 = makeToken(spark, {
+          access_token: 'AT1',
+          scope: 'scope1'
+        });
+
+        const res = {
+          body: {
+            error: 'invalid_request',
+            error_description: 'The refresh token provided is expired, revoked, malformed, or invalid.',
+            trackingID: 'test123'
+          }
+        };
+
+        const ErrorConstructor = grantErrors.select(res.body.error);
+        sinon.stub(st, 'refresh').returns(Promise.reject(new ErrorConstructor('InvalidRequestError')));
+        sinon.stub(credentials, 'unset').returns(Promise.resolve());
+        const triggerSpy = sinon.spy(spark, 'trigger');
+
+        credentials.set({
+          supertoken: st,
+          userTokens: [
+            t1
+          ]
+        });
+
+        return credentials.refresh()
+          .then(() => assert.called(st.refresh))
+          .catch(() => {
+            assert.called(credentials.unset);
+            assert.calledWith(triggerSpy, sinon.match('client:InvalidRequestError'));
+          });
       });
     });
 


### PR DESCRIPTION
# Pull Request Template

## Description

The change fixes the issue where the refresh_token is expired for a user, as a result when a request for refreshing the access_token is made, it fails too with an error "The refresh token provided is expired, revoked, malformed, or invalid". This results in hanging of the web-client. We would want the user to be logged out when this condition is met.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-5100

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
