### PR TITLE
feat (@ciscospark/i-p-wdm) High Availability Messaging

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/index.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/index.js
@@ -9,12 +9,14 @@ import config from './config';
 import UrlInterceptor from './interceptors/url';
 import DeviceUrlInterceptor from './interceptors/device-url';
 import EmbargoInterceptor from './interceptors/embargo';
+import ServerErrorInterceptor from './interceptors/server-error';
 
 registerInternalPlugin('device', Device, {
   interceptors: {
     UrlInterceptor: UrlInterceptor.create,
     DeviceUrlInterceptor: DeviceUrlInterceptor.create,
-    EmbargoInterceptor: EmbargoInterceptor.create
+    EmbargoInterceptor: EmbargoInterceptor.create,
+    ServerErrorInterceptor: ServerErrorInterceptor.create
   },
   config,
   onBeforeLogout() {
@@ -32,4 +34,5 @@ export {default as ServiceModel} from './device/service-model';
 export {default as EmbargoInterceptor} from './interceptors/embargo';
 export {default as UrlInterceptor} from './interceptors/url';
 export {default as DeviceUrlInterceptor} from './interceptors/device-url';
+export {default as ServerErrorInterceptor} from './interceptors/server-error';
 export {default as config} from './config';

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
@@ -1,0 +1,43 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {Interceptor} from '@ciscospark/http-core';
+import {SparkHttpError} from '@ciscospark/spark-core';
+/**
+ * Changes server url when it fails
+ */
+export default class ServerErrorInterceptor extends Interceptor {
+  /**
+  * @returns {HAMessagingInterceptor}
+  */
+  static create() {
+    // eslint-disable-next-line no-invalid-this
+    return new ServerErrorInterceptor({spark: this});
+  }
+
+
+  /**
+   * @see Interceptor#onResponseError
+   * @param {Object} options
+   * @param {Object} reason
+   * @returns {Object}
+   */
+  onResponseError(options, reason) {
+    const feature = this.spark.internal.device.features.developer.get('web-ha-messaging');
+    if (feature && feature.value) {
+      if (options.uri) {
+        if (reason instanceof SparkHttpError.InternalServerError) {
+          this.spark.internal.metrics.submitClientMetrics('web-ha', {
+            fields: {success: false},
+            tags: {action: 'failed', error: reason.message, url: options.uri}
+          });
+
+          return this.spark.internal.device.markUrlFailedAndGetNew(options.uri)
+            .then(() => Promise.reject(reason));
+        }
+      }
+    }
+    return Promise.reject(reason);
+  }
+}

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
@@ -24,18 +24,16 @@ export default class ServerErrorInterceptor extends Interceptor {
    * @returns {Object}
    */
   onResponseError(options, reason) {
-    const feature = this.spark.internal.device.features.developer.get('web-ha-messaging');
-    if (feature && feature.value) {
-      if (options.uri) {
-        if (reason instanceof SparkHttpError.InternalServerError) {
-          this.spark.internal.metrics.submitClientMetrics('web-ha', {
-            fields: {success: false},
-            tags: {action: 'failed', error: reason.message, url: options.uri}
-          });
+    if ((reason instanceof SparkHttpError.InternalServerError) && options.uri) {
+      const feature = this.spark.internal.device.features.developer.get('web-ha-messaging');
+      if (feature && feature.value) {
+        this.spark.internal.metrics.submitClientMetrics('web-ha', {
+          fields: {success: false},
+          tags: {action: 'failed', error: reason.message, url: options.uri}
+        });
 
-          return this.spark.internal.device.markUrlFailedAndGetNew(options.uri)
-            .then(() => Promise.reject(reason));
-        }
+        return this.spark.internal.device.markUrlFailedAndGetNew(options.uri)
+          .then(() => Promise.reject(reason));
       }
     }
     return Promise.reject(reason);

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
@@ -1,0 +1,115 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import Device, {ServerErrorInterceptor} from '@ciscospark/internal-plugin-wdm';
+import MockSpark from '@ciscospark/test-helper-mock-spark';
+import {SparkHttpError} from '@ciscospark/spark-core';
+
+describe('plugin-wdm', () => {
+  describe('ServerErrorInterceptor', () => {
+    let interceptor, spark;
+    const options = {
+      service: 'example',
+      uri: 'http://example-1.com/a-service',
+      headers: {
+        trackingid: 'test'
+      }
+    };
+    beforeEach(() => {
+      spark = new MockSpark({
+        children: {
+          device: Device
+        }
+      });
+
+      spark.internal.device.url = 'https://wdm-a.example.com/devices/id';
+      spark.internal.device.services = {
+        exampleServiceUrl: 'http://example.com/a-service'
+      };
+      spark.internal.metrics.submitClientMetrics = sinon.stub();
+      spark.internal.device.serviceCatalog.set({
+        service: 'exampleServiceUrl',
+        defaultUrl: 'http://example.com/a-service',
+        availableHosts: [
+          {
+            host: 'example-1.com',
+            priority: 1
+          },
+          {
+            host: 'example-2.com',
+            priority: 2
+          }]
+      });
+
+      interceptor = new ServerErrorInterceptor({spark});
+
+      spark.internal.device.features.developer.set([{
+        key: 'web-ha-messaging',
+        val: 'true',
+        value: true,
+        mutable: true,
+        lastModified: '2015-06-29T20:02:48.033Z'
+      }]);
+    });
+
+    describe('#onResponseError()', () => {
+      [
+        new SparkHttpError.InternalServerError({statusCode: 500, options}),
+        new SparkHttpError.BadGateway({statusCode: 502, options}),
+        new SparkHttpError.ServiceUnavailable({statusCode: 503, options}),
+        new SparkHttpError.GatewayTimeout({statusCode: 504, options})
+      ].forEach((error) => {
+        it(`changes new service url on server error code ${error.statusCode}`, () => assert.isRejected(interceptor.onResponseError(options, error))
+          .then(() => spark.internal.device.getServiceUrl('example'))
+          .then((url) => {
+            assert.equal(url, 'http://example-2.com/a-service');
+          }));
+      });
+
+      it('leaves service url as is on other error code', () => assert.isRejected(interceptor.onResponseError(
+        options,
+        new SparkHttpError.NotFound({statusCode: 404, options})
+      ))
+        .then(() => spark.internal.device.getServiceUrl('example'))
+        .then((url) => {
+          assert.equal(url, 'http://example-1.com/a-service');
+        }));
+      describe('when web-ha-messasing is not enabled', () => {
+        beforeEach('sets web-ha-messaging to false', () => {
+          spark.internal.device.features.developer.set([{
+            key: 'web-ha-messaging',
+            val: 'false',
+            value: false,
+            mutable: true,
+            lastModified: '2015-06-29T20:02:48.033Z'
+          }]);
+
+          sinon.spy(spark.internal.device, 'markUrlFailedAndGetNew');
+        });
+
+        [
+          new SparkHttpError.InternalServerError({statusCode: 500, options}),
+          new SparkHttpError.Forbidden({statusCode: 403, options})
+        ].forEach((errorCode) => {
+          it('does not mark url as failed', () => assert.isRejected(interceptor.onResponseError(
+            {
+              service: 'example',
+              uri: 'http://example.com/a-service'
+            },
+            {
+              statusCode: errorCode
+            }
+          ))
+            .then(() => spark.internal.device.getServiceUrl('example'))
+            .then((url) => {
+              assert.notCalled(spark.internal.device.markUrlFailedAndGetNew);
+              assert.equal(url, 'http://example.com/a-service');
+            }));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Implement HA failover for services on failed requests

# Pull Request Template

## Description
Add HA failover when a service request fails for certain error conditions.

This is Tran Tu's code updated so unit tests pass. Ian had asked if the request should be resubmitted and that could be implemented but... Tran's work is pretty impeccable and I would like to try this implementation before making additional changes. HA is only executed with the web-ha-messaging flag set so no one should see a difference until further real world testing is completed. 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ensure host change on selected internal server error conditions
- [x] Ensure current behavior when web-ha-messaging feature flag is not set

**Test Configuration**:
* SDK Version
* Node/Browser Version 8.9.4
* NPM Version 5.8.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
