### PR TITLE
fix(media-engine-webrtc): allow replacement of tracks in call

### DIFF
--- a/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
+++ b/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
@@ -672,8 +672,8 @@ export default class WebRTCMediaEngine {
     const existing = this.pc.getSenders().find((s) => s.track.kind === track.kind && s.track !== track);
     if (existing) {
       this.logger.info(`removing previous ${track.kind} from local media stream`);
-      this.pc.removeTrack(existing);
       this.localMediaStream.removeTrack(existing.track);
+      this.pc.removeTrack(existing);
       // it may not be appropriate to stop the track if it was supplied by the
       // engine consumer, but I'm inclined not to deal with that unless it
       // becomes a real issue.


### PR DESCRIPTION
## Description

Remove the old track from the localMediaStream first before completely removing it from the peerConnection.

Fixes #858

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Test coverage for this is dicey. Need some help seeing how we can test this.

**Test Configuration**:
* SDK Version: `v1.29.5`
* Node/Browser Version: `v8.9.4`
* NPM Version: `5.7.1`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
