### PR TITLE
fix(i-p-mercury): kick off syncing process on network reconnect

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -182,8 +182,8 @@ const Mercury = SparkPlugin.extend({
           }
         });
         callback();
+        return this.spark.internal.device._fetchNewUrls(attemptWSUrl);
       })
-      .then(() => this.spark.internal.device._fetchNewUrls(attemptWSUrl))
       .catch((reason) => {
         // Suppress connection errors that appear to be network related. This
         // may end up suppressing metrics during outages, but we might not care

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -183,6 +183,7 @@ const Mercury = SparkPlugin.extend({
         });
         callback();
       })
+      .then(() => this.spark.internal.device._fetchNewUrls(attemptWSUrl))
       .catch((reason) => {
         // Suppress connection errors that appear to be network related. This
         // may end up suppressing metrics during outages, but we might not care

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -182,7 +182,7 @@ const Mercury = SparkPlugin.extend({
           }
         });
         callback();
-        return this.spark.internal.device._fetchNewUrls(attemptWSUrl);
+        return this.spark.internal.device.fetchNewUrls(attemptWSUrl);
       })
       .catch((reason) => {
         // Suppress connection errors that appear to be network related. This

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -150,11 +150,12 @@ const Device = SparkPlugin.extend({
       return Promise.reject(new Error('`url` is a required parameter'));
     }
 
-    this.logger.info(`device: Reset the available hosts if we are done trying all the host and then retry ${url}`);
-    return this.serviceCatalog._resetAllAndRetry(url);
+    this.logger.info(`device: reset available hosts and retry ${url}`);
+    return this.serviceCatalog.resetAllAndRetry(url);
   },
 
-  _fetchNewUrls(url) {
+  // this function is exposed beyond the device file
+  fetchNewUrls(url) {
     // we want to get the current service first, just in case the
     // refreshed catalog has different host names
     return new Promise((resolve) => this.serviceCatalog.inferServiceFromUrl(url)

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -141,8 +141,17 @@ const Device = SparkPlugin.extend({
         return uri;
       })
       // it's likely we fail here because we've cycled though all hosts,
-      // now we rely on wdm service to return new available datacenters
-      .catch(() => this._fetchNewUrls(url));
+      // reset all hosts and then retry connecting
+      .catch(() => this._resetAllAndRetry(url));
+  },
+
+  _resetAllAndRetry(url) {
+    if (!url) {
+      return Promise.reject(new Error('`url` is a required parameter'));
+    }
+
+    this.logger.info(`device: Reset the available hosts if we are done trying all the host and then retry ${url}`);
+    return this.serviceCatalog._resetAllAndRetry(url);
   },
 
   _fetchNewUrls(url) {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
@@ -37,7 +37,7 @@ const ServiceCollection = AmpCollection.extend({
    * @param {string} uri to fetch the available hosts
    * @returns {string} new Url for connection
    */
-  _resetAllAndRetry(uri) {
+  resetAllAndRetry(uri) {
     if (!uri) {
       return Promise.reject(new Error('`uri` is a required parameter'));
     }

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-collection.js
@@ -33,6 +33,23 @@ const ServiceCollection = AmpCollection.extend({
   },
 
   /**
+   * Reset the available hosts if we are done trying all the host URLs
+   * @param {string} uri to fetch the available hosts
+   * @returns {string} new Url for connection
+   */
+  _resetAllAndRetry(uri) {
+    if (!uri) {
+      return Promise.reject(new Error('`uri` is a required parameter'));
+    }
+
+    return this.inferServiceFromUrl(uri)
+      .then((service) => {
+        service.resetAllHosts();
+        return service.url;
+      });
+  },
+
+  /**
    * Find out what service this url belongs to (by looking at the host name)
    * @param {string} uri
    * @returns {Promise<ServiceModel>}

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/service-model.js
@@ -175,6 +175,16 @@ const ServiceModel = AmpState.extend({
   },
 
   /**
+   * Resets all host/datacenter for a retry
+   * @returns {undefined}
+   */
+  resetAllHosts() {
+    this.availableHosts.forEach((host) => {
+      host.failed = false;
+    });
+  },
+
+  /**
    * Replace provided url by the current active host
    * @param {string} uri
    * @returns {string} uri

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/ping.js
@@ -65,10 +65,11 @@ describe('plugin-wdm', function () {
        * key or have been/will soon be decommissioned but are still in the
        * catalog.
        */
-      const unreachableServices = [
+      const ignoredServices = [
         'mercuryAlternateDC',
         'speechServicesManager',
-        'stickies'
+        'stickies',
+        'xapi'
       ];
 
       knownServices.forEach((service) => {
@@ -81,7 +82,7 @@ describe('plugin-wdm', function () {
         it('responds to pings', () => Object.keys(spark.internal.device.services)
           .map((service) => service.replace('ServiceUrl', ''))
           .filter((service) => !knownServices.includes(service))
-          .filter((service) => !knownServices.includes(service) && !unreachableServices.includes(service))
+          .filter((service) => !knownServices.includes(service) && !ignoredServices.includes(service))
           .reduce((p, service) => p.then(() => ping(service)), Promise.resolve()));
       });
 

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -155,8 +155,9 @@ describe('plugin-wdm', () => {
         it('returns service url for the next available host', () => device.markUrlFailedAndGetNew('https://mercury-connection.a6.ciscospark.com/v1')
           .then((result) => assert.deepEqual(result, 'https://mercury-connection-a5.wbx2.com/v1')));
 
-        it('calls refresh to get new data if it cycled through all the hosts', () => {
+        it('recycle through the hosts after all attempts failed', () => {
           sinon.spy(device, 'refresh');
+          sinon.spy(device, '_resetAllAndRetry');
           assert.notCalled(device.refresh);
           device.services = {
             failingServiceUrl: 'http://fail.com/v1'
@@ -176,36 +177,12 @@ describe('plugin-wdm', () => {
             }
           };
 
-          const request = device.spark.request;
-          assert.isTrue(device.registered);
-          request.onCall(0).returns(Promise.resolve({
-            body: {
-              services: {
-                failingServiceUrl: 'http://fail.com/v1'
-              },
-              serviceHostMap: {
-                hostCatalog: {
-                  'fail.com': [
-                    {
-                      host: 'new-4.com',
-                      priority: 2
-                    },
-                    {
-                      host: 'new-3.com',
-                      priority: 1
-                    }
-                  ]
-                }
-              }
-            }
-          }));
-
           return device.markUrlFailedAndGetNew('http://fail-1.com/v1')
             .then((result) => assert.deepEqual(result, 'http://fail-2.com/v1'))
-            .then(() => device.markUrlFailedAndGetNew('http://fail-2.com/v1')
-              .then((result) => assert.deepEqual(result, 'http://new-3.com/v1')))
+            .then(() => device.markUrlFailedAndGetNew('http://fail-2.com/v1'))
             .then(() => {
-              assert.calledOnce(device.refresh);
+              assert.notCalled(device.refresh);
+              assert.called(device._resetAllAndRetry);
             });
         });
       });

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -155,7 +155,7 @@ describe('plugin-wdm', () => {
         it('returns service url for the next available host', () => device.markUrlFailedAndGetNew('https://mercury-connection.a6.ciscospark.com/v1')
           .then((result) => assert.deepEqual(result, 'https://mercury-connection-a5.wbx2.com/v1')));
 
-        it('recycle through the hosts after all attempts failed', () => {
+        it('recycles through the hosts after all attempts failed', () => {
           sinon.spy(device, 'refresh');
           sinon.spy(device, '_resetAllAndRetry');
           assert.notCalled(device.refresh);


### PR DESCRIPTION
# Pull Request Template

## Description
On a network reconnect the web-client currently fails to sync to fetch the new messages and always displays a 'Reload' banner to load the client manually. On further analysis it is observed that due to HA changes, web-client tends to try different URLs to connect to mercury on failure. After exhausting the mercury URL list, it marks them as failed and tries to do a device re-registration. Since the client is offline, the device registration never succeeds and brings the client in a limbo state. Having exhausted all the mercury URLs, it does not try to reconnect on getting back online again and ends up showing the 'Reload' banner.

The fix is to recycle the mercury URLs, when the list is exhausted, whenever this scenario happens and then attempt connecting them again trying one URL at a time. Also re-register the device on a successful mercury connection.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-14403

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Coverage

**Test Configuration**:
* SDK Version: 1.29.4
* Node/Browser Version - Node: 8.9.4, Chrome: v66
* NPM Version - 5.6.0

To reproduce the issue, after logging in the web-client, simply disconnect it from the network. Wait for at least 15 mins and then reconnect to internet. You would see that the client fails to sync and displays the 'Reload' banner for a manual refresh.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
