### PR TITLE
chore(testing): add ability to limit browsers

### DIFF
--- a/SCRIPTS.md
+++ b/SCRIPTS.md
@@ -54,6 +54,12 @@ Test a single package, but only in a browser
 npm test -- --package @ciscospark/spark-core --browser
 ```
 
+Test a single package, but only in a specific browser
+
+```bash
+BROWSER=chrome npm test -- --package @ciscospark/spark-core --browser
+```
+
 Test a single package and generate coverage and xunit reports
 
 ```bash

--- a/browsers-ng.js
+++ b/browsers-ng.js
@@ -101,5 +101,21 @@ module.exports = function(packageName, argv) {
     }
   }
 
+  // Limit browsers via env variable
+  if (process.env.BROWSER) {
+    const browserName = process.env.BROWSER.toUpperCase();
+    const filteredBrowsers = {};
+    Object.keys(browsers).forEach((browserId) => {
+      const browser = browsers[browserId]
+      if ((browser.base && browser.base.toUpperCase() === browserName) || (browser.browserName && browser.browserName.toUpperCase() === browserName)) {
+        filteredBrowsers[browserId] = browser;
+      }
+    });
+    if (Object.keys(filteredBrowsers).length === 0) {
+      throw new Error('No matching browsers found.');
+    }
+    return filteredBrowsers;
+  }
+
   return browsers;
 }


### PR DESCRIPTION
## Description

Since firefox is a source of pain currently, this change will allow us to provide a command line variable to limit which browser the tests are run on. 

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Phone plugin tests with only chrome

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
