### PR TITLE
fix(credentials): exclude state from URL when it is empty

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/lib/credentials/credentials.js
@@ -13,7 +13,7 @@ import {
   whileInFlight
 } from '@ciscospark/common';
 import {safeSetTimeout} from '@ciscospark/common-timers';
-import {clone, cloneDeep, isObject} from 'lodash';
+import {clone, cloneDeep, isObject, isEmpty} from 'lodash';
 
 import SparkPlugin from '../spark-plugin';
 import {persist, waitForValue} from '../storage/decorators';
@@ -117,7 +117,12 @@ const Credentials = SparkPlugin.extend({
     Reflect.deleteProperty(options, 'clientType');
 
     if (options.state) {
-      options.state = base64.toBase64Url(JSON.stringify(options.state));
+      if (!isEmpty(options.state)) {
+        options.state = base64.toBase64Url(JSON.stringify(options.state));
+      }
+      else {
+        delete options.state;
+      }
     }
     return `${this.config.authorizeUrl}?${querystring.stringify(options)}`;
     /* eslint-enable camelcase */

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/credentials/credentials.js
@@ -165,6 +165,14 @@ describe('spark-core', () => {
 
         assert.equal(credentials.buildLoginUrl({state: {page: 'front'}}), 'https://idbroker.webex.com/idb/oauth2/v1/authorize?state=eyJwYWdlIjoiZnJvbnQifQ&client_id=fake&redirect_uri=http%3A%2F%2Fexample.com&scope=scope%3Aone&response_type=code');
       });
+
+      it('generates the login url with empty state param', () => {
+        const spark = new MockSpark();
+        const credentials = new Credentials(undefined, {parent: spark});
+        spark.trigger('change:config');
+
+        assert.equal(credentials.buildLoginUrl({state: {}}), 'https://idbroker.webex.com/idb/oauth2/v1/authorize?client_id=fake&redirect_uri=http%3A%2F%2Fexample.com&scope=scope%3Aone&response_type=code');
+      });
     });
 
     describe('#buildLogoutUrl()', () => {


### PR DESCRIPTION
# Pull Request 

## Description

If the `state` param was an empty object, it would be encoded and added to the URL.

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SSDK-1931

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

- [x] Added test to ensure the `state` param is excluded from the URL when the object is empty.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

This is unrelated, but a Chrome test is failing:

```
FAILED TESTS:
      #initialize()
        ✖ schedules a refreshTimer
          Chrome 66.0.3359 (Mac OS X 10.13.4)
        AssertError: expected refresh to have been called at least once but was never called
```
