### PR TITLE
test(plugin-phone): reduce the # of test users

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/events-model.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/events-model.js
@@ -673,17 +673,7 @@ browserOnly(describe)('plugin-phone', function () {
           rs7: null,
           rs8: null,
           rs9: null,
-          rs10: null,
-          rs11: null,
-          rs12: null,
-          rs13: null,
-          rs14: null,
-          rs15: null,
-          rs16: null,
-          rs17: null,
-          rs18: null,
-          rs19: null,
-          rs20: null
+          rs10: null
         };
 
         setup(users, (r) => {


### PR DESCRIPTION
Integration environment removes notifications for spaces bigger than 15.

## Description
From Locus Team:
> on the test failing in integration on alertType - how easy is it to run the test with <15 test users? I see that we have a config that turns off alerts when number of participants > 15.

> On prod this value is set to 25



## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] plugin-phone on chrome on prod and integration


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
