### PR TITLE
fix(i-p-mercury): fetch new websocket URL when HA enabled

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -181,7 +181,13 @@ const Mercury = SparkPlugin.extend({
           }
         });
         callback();
-        return this.spark.internal.device.fetchNewUrls(attemptWSUrl);
+        return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+          .then((haMessagingEnabled) => {
+            if (haMessagingEnabled) {
+              return this.spark.internal.device.fetchNewUrls(attemptWSUrl);
+            }
+            return Promise.resolve();
+          });
       })
       .catch((reason) => {
         // Suppress connection errors that appear to be network related. This


### PR DESCRIPTION
## Description

Adds a check to make sure HA is enabled before fetching the new websocket URL list as part of HA work.

Fixes # (issue) https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-20161

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] All tests on internal-plugin-mercury passed locally

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
