### PR TITLE
Fix redirect URL

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/src/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/src/authorization.js
@@ -8,7 +8,7 @@ import querystring from 'querystring';
 import url from 'url';
 import {base64, oneFlight, whileInFlight} from '@ciscospark/common';
 import {grantErrors, SparkPlugin} from '@ciscospark/spark-core';
-import {cloneDeep, omit} from 'lodash';
+import {cloneDeep, isEmpty, omit} from 'lodash';
 import uuid from 'uuid';
 
 const OAUTH2_CSRF_TOKEN = 'oauth2-csrf-token';
@@ -239,7 +239,12 @@ const Authorization = SparkPlugin.extend({
         'refresh_token',
         'refresh_token_expires_in'
       ].forEach((key) => Reflect.deleteProperty(location.hash, key));
-      location.hash.state = base64.encode(JSON.stringify(omit(location.hash.state, 'csrf_token')));
+      if (!isEmpty(location.hash.state)) {
+        location.hash.state = base64.encode(JSON.stringify(omit(location.hash.state, 'csrf_token')));
+      }
+      else {
+        Reflect.deleteProperty(location.hash, 'state');
+      }
       location.hash = querystring.stringify(location.hash);
       this.spark.getWindow().history.replaceState({}, null, url.format(location));
     }

--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
@@ -290,9 +290,7 @@ browserOnly(describe)('plugin-authorization-browser', () => {
         });
         sinon.spy(spark.authorization, '_cleanUrl');
         [{}, {state: {}}].forEach((hash) => {
-          const location = {
-            hash
-          };
+          const location = {hash};
           spark.authorization._cleanUrl(location);
           assert.equal(spark.getWindow().location.href, '');
         });

--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
@@ -288,14 +288,36 @@ browserOnly(describe)('plugin-authorization-browser', () => {
             clientType: 'confidential'
           }
         });
+        sinon.spy(spark.authorization, '_cleanUrl');
+        [{}, {state: {}}].forEach((hash) => {
+          const location = {
+            hash
+          };
+          spark.authorization._cleanUrl(location);
+          assert.equal(spark.getWindow().location.href, '');
+        });
+      });
+
+      it('keeps the state parameter when it has keys', () => {
+        const spark = makeSpark(undefined, undefined, {
+          credentials: {
+            clientType: 'confidential'
+          }
+        });
         const location = {
           hash: {
-
+            state: {
+              csrf_token: 'token',
+              key: 'value'
+            }
           }
         };
         sinon.spy(spark.authorization, '_cleanUrl');
         spark.authorization._cleanUrl(location);
-        assert.equal(spark.getWindow().location.href, '');
+        const href = spark.getWindow().location.href;
+        assert.isDefined(href);
+        assert.equal(href, `#state=${base64.encode(JSON.stringify({key: 'value'}))}`);
+        assert.notInclude(href, 'csrf_token');
       });
     });
 

--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
@@ -281,6 +281,24 @@ browserOnly(describe)('plugin-authorization-browser', () => {
       });
     });
 
+    describe('#_cleanUrl()', () => {
+      it('removes the state parameter when it is empty', () => {
+        const spark = makeSpark(undefined, undefined, {
+          credentials: {
+            clientType: 'confidential'
+          }
+        });
+        const location = {
+          hash: {
+
+          }
+        };
+        sinon.spy(spark.authorization, '_cleanUrl');
+        spark.authorization._cleanUrl(location);
+        assert.equal(spark.getWindow().location.href, '');
+      });
+    });
+
     describe('#initiateImplicitGrant()', () => {
       it('redirects to the login page with response_type=token', () => {
         const spark = makeSpark(undefined, undefined, {


### PR DESCRIPTION
# Pull Request

## Description

Remove `#state=e30` (an encoded empty object) from the redirect URL when an empty state object is provided. 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/DXDOC-212, https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-20334

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Added tests to check for empty and non-empty cases for the object `state`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
