### PR TITLE
fix(spark-core): correctly use trackingIdSuffix, enforce static prefix

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/config.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/config.js
@@ -13,7 +13,8 @@ export default {
   maxAuthenticationReplays: 1,
   maxReconnectAttempts: 1,
   onBeforeLogout: [],
-  trackingIdPrefix: 'spark-js-sdk',
+  // Attaches a prefix AFTER `spark-js-sdk` (i.e. `spark-js-sdk_${trackingIdPrefix}`)
+  trackingIdPrefix: '',
   trackingIdSuffix: '',
   AlternateLogger: undefined,
   credentials: {

--- a/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
@@ -346,9 +346,14 @@ const SparkCore = AmpState.extend({
       interceptors: ints
     });
 
-    let sessionId = `${get(this, 'config.trackingIdPrefix', 'spark-js-sdk')}_${get(this, 'config.trackingIdBase', uuid.v4())}`;
+    let sessionId = 'spark-js-sdk_';
+
     if (has(this, 'config.trackingIdPrefix')) {
-      sessionId += `_${get(this, 'config.trackingIdPrefix')}`;
+      sessionId += `${get(this, 'config.trackingIdPrefix')}_`;
+    }
+    sessionId += get(this, 'config.trackingIdBase', uuid.v4());
+    if (has(this, 'config.trackingIdSuffix')) {
+      sessionId += `_${get(this, 'config.trackingIdSuffix')}`;
     }
 
     this.sessionId = sessionId;


### PR DESCRIPTION
## Description

Allows us to use `trackingIdSuffix`. This also forces `spark-js-sdk` as a prefix to `trackingIdPrefix` as that specific string is necessary for Id filtering on the server.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] spark-core

**Test Configuration**:
* SDK Version: 1.32.21
* Node/Browser Version: 8.9.4
* NPM Version: 5.7.1

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
