### PR TITLE
fix(i-p-wdm): resets logout timer after receiving pong

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -384,10 +384,10 @@ const Device = SparkPlugin.extend({
 
   _resetLogoutTimer() {
     clearTimeout(this.logoutTimer);
+    this.off('change:lastUserActivityDate'); // removes previous event listener
     this.unset('logoutTimer');
     if (this.config.enableInactivityEnforcement && this.intranetInactivityCheckUrl && this.intranetInactivityDuration) {
-      this.once('change:lastUserActivityDate', () => this._resetLogoutTimer());
-
+      this.on('change:lastUserActivityDate', () => this._resetLogoutTimer());
       const timer = safeSetTimeout(() => {
         this.spark.request({
           headers: {
@@ -398,7 +398,6 @@ const Device = SparkPlugin.extend({
           method: 'GET',
           uri: this.intranetInactivityCheckUrl
         })
-          .then(() => this._resetLogoutTimer()) // reset the timer on successful ping
           .catch(() => {
             this.logger.info('device: did not reach internal ping endpoint; logging out after inactivity on a public network');
             return this.spark.logout();

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -398,6 +398,7 @@ const Device = SparkPlugin.extend({
           method: 'GET',
           uri: this.intranetInactivityCheckUrl
         })
+          .then(() => this._resetLogoutTimer()) // reset the timer on successful ping
           .catch(() => {
             this.logger.info('device: did not reach internal ping endpoint; logging out after inactivity on a public network');
             return this.spark.logout();

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/policy.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/policy.js
@@ -167,22 +167,22 @@ describe('plugin-wdm', () => {
             const resetLogoutTimerSpy = sinon.spy(spark.internal.device, '_resetLogoutTimer');
             spark.emit('user-activity');
             clock.tick(1 * 60 * 60 * 1000);
-            assert.equal(resetLogoutTimerSpy.callCount, 2);
+            assert.equal(resetLogoutTimerSpy.callCount, 1);
             resetLogoutTimerSpy.reset();
 
             spark.emit('user-activity');
             clock.tick(1 * 60 * 60 * 1000);
-            assert.equal(resetLogoutTimerSpy.callCount, 2);
+            assert.equal(resetLogoutTimerSpy.callCount, 1);
             resetLogoutTimerSpy.reset();
 
             spark.emit('user-activity');
             clock.tick(1 * 60 * 60 * 1000);
-            assert.equal(resetLogoutTimerSpy.callCount, 2);
+            assert.equal(resetLogoutTimerSpy.callCount, 1);
             resetLogoutTimerSpy.reset();
 
             spark.emit('user-activity');
             clock.tick(1 * 60 * 60 * 1000);
-            assert.equal(resetLogoutTimerSpy.callCount, 2);
+            assert.equal(resetLogoutTimerSpy.callCount, 1);
             resetLogoutTimerSpy.reset();
           });
         });


### PR DESCRIPTION
## Description
The logout timer currently runs only once to determine if the client is inside or outside the corporate boundary and hence does not handle the case where in the client goes outside the boundary after the first check. We need to reset the logout timer after every successful check so that it keeps checking after some interval.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-25130

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Coverage
All tests on internal-plugin-wdm passes locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
