### PR TITLE
Reinstate recipe-private-web-client

### DIFF
--- a/packages/node_modules/@ciscospark/recipe-private-web-client/README.md
+++ b/packages/node_modules/@ciscospark/recipe-private-web-client/README.md
@@ -1,0 +1,9 @@
+# @ciscospark/recipe-private-web-client
+
+## WARNING
+
+We renamed this module to [@webex/recipe-private-web-client](https://www.npmjs.com/package/@webex/recipe-private-web-client). Please install it instead.
+
+## License
+
+© 2016-2018 Cisco and/or its affiliates. All Rights Reserved.

--- a/packages/node_modules/@webex/recipe-private-web-client/README.md
+++ b/packages/node_modules/@webex/recipe-private-web-client/README.md
@@ -1,0 +1,33 @@
+# @webex/recipe-private-web-client
+
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> Transitional package for web client. **DO NOT USE** in new projects.
+
+- [Install](#install)
+- [Usage](#usage)
+- [Contribute](#contribute)
+- [Maintainers](#maintainers)
+- [License](#license)
+
+## Install
+
+```bash
+npm install --save @webex/recipe-private-web-client
+```
+
+## Usage
+
+Transitional package for web client. **DO NOT USE** in new projects.
+
+## Maintainers
+
+This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).
+
+## Contribute
+
+Pull requests welcome. Please see [CONTRIBUTING.md](https://github.com/webex/spark-js-sdk/blob/master/CONTRIBUTING.md) for more details.
+
+## License
+
+© 2016-2018 Cisco and/or its affiliates. All Rights Reserved.

--- a/packages/node_modules/@webex/recipe-private-web-client/package.json
+++ b/packages/node_modules/@webex/recipe-private-web-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@webex/recipe-private-web-client",
+  "version": "1.32.15",
+  "description": "This is a plugin recipe for the Cisco Webex JS SDK. This recipe uses internal APIs to provide the features needed by the Cisco Webex Teams Client. There is no guarantee of non-breaking changes. Non-Cisco engineers should stick to the `ciscospark` package.",
+  "license": "MIT",
+  "author": "Ian W. Remmel <iremmel@cisco.com>",
+  "main": "dist/index.js",
+  "devMain": "src/index.js",
+  "repository": "https://github.com/webex/spark-js-sdk/tree/master/packages/node_modules/@webex/recipe-private-web-client",
+  "engines": {
+    "node": ">=4"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      "envify"
+    ]
+  }
+}

--- a/packages/node_modules/@webex/recipe-private-web-client/src/config.js
+++ b/packages/node_modules/@webex/recipe-private-web-client/src/config.js
@@ -1,0 +1,16 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import LocalForageStoreAdapter from '@ciscospark/storage-adapter-local-forage';
+import LocalStorageStoreAdapter from '@ciscospark/storage-adapter-local-storage';
+
+export default {
+  device: {
+    enableInactivityEnforcement: true
+  },
+  storage: {
+    boundedAdapter: new LocalStorageStoreAdapter('web-client-internal'),
+    unboundedAdapter: new LocalForageStoreAdapter('web-client-internal')
+  }
+};

--- a/packages/node_modules/@webex/recipe-private-web-client/src/index.js
+++ b/packages/node_modules/@webex/recipe-private-web-client/src/index.js
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import '@ciscospark/plugin-authorization-browser-first-party';
+import '@ciscospark/internal-plugin-avatar';
+import '@ciscospark/internal-plugin-board';
+import '@ciscospark/internal-plugin-calendar';
+import '@ciscospark/internal-plugin-conversation';
+import '@ciscospark/internal-plugin-encryption';
+import '@ciscospark/internal-plugin-feature';
+import '@ciscospark/internal-plugin-flag';
+import '@ciscospark/plugin-logger';
+import '@ciscospark/internal-plugin-mercury';
+import '@ciscospark/internal-plugin-metrics';
+import '@ciscospark/internal-plugin-search';
+import '@ciscospark/internal-plugin-support';
+import '@ciscospark/internal-plugin-team';
+import '@ciscospark/internal-plugin-user';
+import '@ciscospark/internal-plugin-lyra';
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/plugin-people';
+
+import config from './config';
+import SparkCore from '@ciscospark/spark-core';
+import {merge} from 'lodash';
+
+/**
+ * @param {Object} attrs
+ * @param {Object} attrs.config
+ * @returns {Spark}
+ */
+export default function CiscoSpark(attrs) {
+  attrs = attrs || {};
+  attrs.config = merge(config, attrs.config);
+  return new SparkCore(attrs);
+}

--- a/tooling/lint-package-names.sh
+++ b/tooling/lint-package-names.sh
@@ -5,7 +5,8 @@ shopt -s extglob
 
 DEPRECATED_PACKAGES="@ciscospark/storage-adapter-session-storage \
   @ciscospark/test-helper-automation \
-  @ciscospark/sparkd"
+  @ciscospark/sparkd \
+  @ciscospark/recipe-private-web-client"
 
 PACKAGES=$(echo packages/node_modules/{*,@ciscospark/*,@webex/*} | xargs -n 1 | sed 's/packages\/node_modules\///' | xargs -n 1 | grep -v '^@ciscospark$' | grep -v '^samples$' | grep -v '^@webex$')
 for PACKAGE in $PACKAGES; do


### PR DESCRIPTION
# Pull Request

## Description

There was a note on the `@ciscospark/recipe-private-web-client` package to remove it. However, the web client is still using this package. 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-26483

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
