### PR TITLE
feat(i-p-wdm): Add whiteboardFileShareControl property to device

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -70,7 +70,18 @@ const Device = SparkPlugin.extend({
      * @type {string}
      */
     webFileShareControl: 'string',
-    webSocketUrl: 'string'
+    webSocketUrl: 'string',
+    /**
+     * Notifies the client if whiteboarding should be allowed
+     * regardless of webFileShareControl settings.
+     * Currently, the values for it are:
+     * - ALLOW
+     * - BLOCK
+     * @instance
+     * @memberof Device
+     * @type {string}
+     */
+    whiteboardFileShareControl: 'string'
   },
 
   derived: {


### PR DESCRIPTION
Pass along "new" wdm property to device spark.internal.device users

# Pull Request Template

## Description

Add whiteboardFileShareControl property to device, provide access to wdm property for whiteboard enabling / disabling within the context of file sharing permissions (ie no file uploads are allowed but whiteboard is allowed).

Fixes # (issue)

## Type of Change
property descriptor

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
