### PR TITLE
feat(plugin-phone): remove call:created event for inactive loci

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/phone.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/phone.js
@@ -244,17 +244,20 @@ const Phone = SparkPlugin.extend({
    * @returns {undefined}
    */
   onLocusEvent(event) {
-    // We only want to handle calls we are not aware of
-    if (this.emittedCalls.has(event.data.locus)) {
+    const {locus} = event.data;
+
+    // We only want to handle calls we are not aware of in an active state
+    if (this.emittedCalls.has(locus) || locus.fullState.state.toLowerCase() === 'inactive') {
       return;
     }
 
     // Create call object and store in emittedCalls
     const call = Call.make({
-      locus: event.data.locus
+      locus
     }, {
       parent: this.spark
     });
+
     this.emittedCalls.add(call);
 
     // Trigger events as necessary

--- a/packages/node_modules/@ciscospark/plugin-phone/test/lib/locus.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/lib/locus.js
@@ -1,9 +1,10 @@
 export function makeLocus({
-  id = 1, lastActive = 1, correlationId = 1, sequence = [1], replaces
+  id = 1, lastActive = 1, correlationId = 1, sequence = [1], replaces, state = 'active'
 }) {
   const locus = {
     fullState: {
       lastActive,
+      state,
       type: 'CALL'
     },
     participants: [

--- a/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/phone.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/phone.js
@@ -153,5 +153,86 @@ browserOnly(describe)('plugin-phone', () => {
           });
       });
     });
+
+    describe('call:created event', () => {
+      let spark;
+      beforeEach(() => {
+        spark = new MockSpark({
+          children: {
+            device: Device,
+            mercury: Mercury,
+            locus: Locus,
+            phone: Phone
+          }
+        });
+        spark.people = {
+          inferPersonIdFromUuid(id) {
+            return id;
+          }
+        };
+        spark.config.phone = {audioBandwidthLimit: 64000, videoBandwidthLimit: 1000000};
+      });
+
+      it('should emit a call:created event when a new locus arrives', () => {
+        const spy = sinon.spy();
+        spark.phone.on('call:created', spy);
+        const id = Date.now();
+        spark.internal.mercury._onmessage(makeLocusEvent({
+          id,
+          lastActive: 1
+        }));
+        return Promise.resolve()
+          .then(() => {
+            assert.calledOnce(spy);
+            spark.internal.mercury._onmessage(makeLocusEvent({
+              id,
+              lastActive: 1
+            }));
+          });
+      });
+
+      it('should not emit a call:created event when a locus arrives that is already known', () => {
+        const spy = sinon.spy();
+        spark.phone.on('call:created', spy);
+
+        const id = Date.now();
+
+        spark.internal.mercury._onmessage(makeLocusEvent({
+          id,
+          lastActive: 1
+        }));
+
+        return Promise.resolve()
+          .then(() => {
+            assert.calledOnce(spy);
+            spark.internal.mercury._onmessage(makeLocusEvent({
+              id,
+              lastActive: 1
+            }));
+          })
+          .then(() => {
+            // calls:created event should not trigger again
+            assert.calledOnce(spy);
+          });
+      });
+
+      it('should not emit a call:created event when a locus arrives that is inactive', () => {
+        const spy = sinon.spy();
+        spark.phone.on('call:created', spy);
+
+        const id = Date.now();
+
+        spark.internal.mercury._onmessage(makeLocusEvent({
+          id,
+          lastActive: 1,
+          state: 'inactive'
+        }));
+
+        return Promise.resolve()
+          .then(() => {
+            assert.notCalled(spy);
+          });
+      });
+    });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description

Call objects will still emit locus events, but the main phone pluginshould not create calls for inactive locus events.

Fixes # SPARK-18814

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Plugin-phone tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
