### PR TITLE
feat(plugin-meetings): initial plugin scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test:samples": "echo 'Deprecated. Please use npm run samples:test'; npm run --silent samples:test",
     "samples:build": "babel-node ./tooling/index.js build --only-samples",
     "samples:serve": "webpack-dev-server",
+    "serve:package": "webpack-dev-server --config webpack/webpack.config.js --hot --inline --history-api-fallback",
     "presamples:test": "rimraf bundle.js bundle.js.map",
     "samples:test": "NODE_ENV=test wdio",
     "tooling": "babel-node ./tooling/index.js",
@@ -223,6 +224,7 @@
     "webpack": "^4.12.0",
     "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.2",
+    "webpack-merge": "^4.1.4",
     "webrtc-adapter": "^6.1.0",
     "whatwg-fetch": "^2.0.3",
     "ws": "^4.0.0",
@@ -263,5 +265,8 @@
     "Jenkinsfile": "lint:jenkinsfile",
     "*package.json": "lint:package-names"
   },
-  "snyk": true
+  "snyk": true,
+  "devDependencies": {
+    "html-webpack-plugin": "^3.2.0"
+  }
 }

--- a/packages/node_modules/@webex/plugin-meetings/README.md
+++ b/packages/node_modules/@webex/plugin-meetings/README.md
@@ -1,0 +1,43 @@
+# @webex/plugin-meetings
+
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> Logging plugin for the Cisco Webex JS SDK.
+
+- [Install](#install)
+- [Usage](#usage)
+- [Development](#development)
+- [Contribute](#contribute)
+- [Maintainers](#maintainers)
+- [License](#license)
+
+
+## Install
+
+```bash
+npm install --save @webex/plugin-meetings
+```
+
+## Usage
+
+This is a plugin for the Cisco Webex JS SDK . Please see our [developer portal](https://developer.webex.com/sdks-and-widgets.html) and the [API docs](https://webex.github.io/spark-js-sdk/api/) for full details.
+
+## Development
+
+To use `webpack-dev-server` to load this package, run `npm run serve:package -- --env.package @webex/plugin-meetings` from the root of this repo.
+
+Files placed in the `samples` folder will be served statically.
+
+Files in the `src` folder will be compiled, bundled, and served as a static asset at `bundle.js`.
+
+## Maintainers
+
+This package is maintained by [Cisco Webex for Developers](https://developer.webex.com/).
+
+## Contribute
+
+Pull requests welcome. Please see [CONTRIBUTING.md](https://github.com/webex/spark-js-sdk/blob/master/CONTRIBUTING.md) for more details.
+
+## License
+
+© 2016-2018 Cisco and/or its affiliates. All Rights Reserved.

--- a/packages/node_modules/@webex/plugin-meetings/package.json
+++ b/packages/node_modules/@webex/plugin-meetings/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@webex/plugin-meetings",
+  "version": "1.32.28",
+  "description": "",
+  "license": "MIT",
+  "contributors": [
+    "Bernie Zang <nzang@cisco.com>"
+  ],
+  "main": "dist/index.js",
+  "devMain": "src/index.js",
+  "repository": "https://github.com/webex/spark-js-sdk/tree/master/packages/node_modules/@ciscospark/plugin-meetings",
+  "engines": {
+    "node": ">=4"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      "envify"
+    ]
+  }
+}

--- a/packages/node_modules/@webex/plugin-meetings/sample/app.js
+++ b/packages/node_modules/@webex/plugin-meetings/sample/app.js
@@ -1,0 +1,126 @@
+/* eslint-env browser */
+
+/* global ciscospark */
+
+/* eslint-disable camelcase */
+/* eslint-disable max-nested-callbacks */
+/* eslint-disable no-alert */
+/* eslint-disable no-console */
+/* eslint-disable require-jsdoc */
+
+// Declare some globals that we'll need throughout
+let activeMeeting, spark;
+
+// First, let's wire our form fields up to localStorage so we don't have to
+// retype things everytime we reload the page.
+
+[
+  'access-token',
+  'invitee'
+].forEach((id) => {
+  const el = document.getElementById(id);
+  el.value = localStorage.getItem(id);
+  el.addEventListener('change', (event) => {
+    localStorage.setItem(id, event.target.value);
+  });
+});
+
+function connect() {
+  if (!spark) {
+    spark = ciscospark.default.init({
+      config: {
+        // Any other sdk config we need
+      },
+      credentials: {
+        access_token: document.getElementById('access-token').value
+      }
+    });
+  }
+  if (!spark.internal.device.registered) {
+    spark.internal.device.register()
+      .then(() => {
+        // This is just a little helper for our selenium tests and doesn't
+        // really matter for the example
+        document.body.classList.add('listening');
+        document.getElementById('connection-status').innerHTML = 'connected';
+      })
+      // This is a terrible way to handle errors, but anything more specific is
+      // going to depend a lot on your app
+      .catch((err) => {
+        console.error(err);
+        // we'll rethrow here since we didn't really *handle* the error, we just
+        // reported it
+        throw err;
+      });
+  }
+}
+
+// In order to simplify the state management needed to keep track of our button
+// handlers, we'll rely on the current call global object and only hook up event
+// handlers once.
+
+document.getElementById('disconnect').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.disconnect();
+  }
+});
+
+document.getElementById('start-sending-audio').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.startSendingAudio();
+  }
+});
+
+document.getElementById('stop-sending-audio').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.stopSendingAudio();
+  }
+});
+
+document.getElementById('start-sending-video').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.startSendingVideo();
+  }
+});
+
+document.getElementById('stop-sending-video').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.stopSendingVideo();
+  }
+});
+document.getElementById('start-receiving-audio').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.startReceivingAudio();
+  }
+});
+
+document.getElementById('stop-receiving-audio').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.stopReceivingAudio();
+  }
+});
+
+document.getElementById('start-receiving-video').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.startReceivingVideo();
+  }
+});
+
+document.getElementById('stop-receiving-video').addEventListener('click', () => {
+  if (activeMeeting) {
+    activeMeeting.stopReceivingVideo();
+  }
+});
+
+// Now, let's set up incoming call handling
+document.getElementById('credentials').addEventListener('submit', (event) => {
+  // let's make sure we don't reload the page when we submit the form
+  event.preventDefault();
+  connect();
+});
+
+// And finally, let's wire up dialing
+document.getElementById('dialer').addEventListener('submit', (event) => {
+  // again, we don't want to reload when we try to dial
+  event.preventDefault();
+});

--- a/packages/node_modules/@webex/plugin-meetings/sample/app.js
+++ b/packages/node_modules/@webex/plugin-meetings/sample/app.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-/* global ciscospark */
+/* global Meetings, ciscospark */
 
 /* eslint-disable camelcase */
 /* eslint-disable max-nested-callbacks */
@@ -9,7 +9,7 @@
 /* eslint-disable require-jsdoc */
 
 // Declare some globals that we'll need throughout
-let activeMeeting, spark;
+let activeMeeting, spark, meetings;
 
 // First, let's wire our form fields up to localStorage so we don't have to
 // retype things everytime we reload the page.
@@ -27,7 +27,7 @@ let activeMeeting, spark;
 
 function connect() {
   if (!spark) {
-    spark = ciscospark.default.init({
+    spark = ciscospark.init({
       config: {
         // Any other sdk config we need
       },
@@ -35,7 +35,10 @@ function connect() {
         access_token: document.getElementById('access-token').value
       }
     });
+
+    meetings = new Meetings({spark});
   }
+
   if (!spark.internal.device.registered) {
     spark.internal.device.register()
       .then(() => {
@@ -123,4 +126,5 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
 document.getElementById('dialer').addEventListener('submit', (event) => {
   // again, we don't want to reload when we try to dial
   event.preventDefault();
+  meetings.create();
 });

--- a/packages/node_modules/@webex/plugin-meetings/sample/index.html
+++ b/packages/node_modules/@webex/plugin-meetings/sample/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sample: Local Mute/Unmute</title>
+  </head>
+  <body>
+    <h1>Local Mute/Unmute</h1>
+    <p>This sample demonstrates local mute and unmute</p>
+    <form id="credentials">
+      <fieldset>
+        <legend>Credentials</legend>
+        <input
+          id="access-token"
+          name="accessToken"
+          placeholder="Your access token"
+          value=""
+          type="text">
+        <input id="connect" title="connect" type="submit" value="connect">
+        <p id="connection-status">disconnected</p>
+      </fieldset>
+    </form>
+
+    <form id="dialer">
+      <fieldset>
+        <legend>Dialer</legend>
+        <input
+          id="invitee"
+          name="invitee"
+          placeholder="Person ID or Email Address or SIP URI or Room ID"
+          value=""
+          type="text">
+          <input title="create" type="submit" value="create">
+      </fieldset>
+    </form>
+
+    <form id="call-controls">
+      <fieldset>
+        <legend>Call Controls</legend>
+        <button id="disconnect" title="disconnect" type="button">cancel/disconnect</button>
+
+        <button id="stop-sending-audio" title="stop sending audio" type="button">stop sending audio</button>
+        <button id="start-sending-audio" title="start sending audio" type="button">start sending audio</button>
+
+        <button id="stop-sending-video" title="stop sending video" type="button">stop sending video</button>
+        <button id="start-sending-video" title="start sending video" type="button">start sending video</button>
+        <br />
+        <button id="stop-receiving-audio" title="stop receiving audio" type="button">stop receiving audio</button>
+        <button id="start-receiving-audio" title="start receiving audio" type="button">start receiving audio</button>
+
+        <button id="stop-receiving-video" title="stop receiving video" type="button">stop receiving video</button>
+        <button id="start-receiving-video" title="start receiving video" type="button">start receiving video</button>
+      </fieldset>
+    </form>
+
+    <script src="bundle.js"></script>
+    <!-- app.js is your application code -->
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/packages/node_modules/@webex/plugin-meetings/src/ciscospark.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/ciscospark.js
@@ -1,0 +1,38 @@
+import '@ciscospark/plugin-authorization';
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/plugin-logger';
+import '@ciscospark/plugin-messages';
+import '@ciscospark/plugin-memberships';
+import '@ciscospark/plugin-people';
+import '@ciscospark/plugin-rooms';
+import '@ciscospark/plugin-teams';
+import '@ciscospark/plugin-team-memberships';
+import '@ciscospark/plugin-webhooks';
+import SparkCore, {MemoryStoreAdapter} from '@ciscospark/spark-core';
+import merge from 'lodash/merge';
+
+const CiscoSpark = SparkCore.extend({
+  ciscospark: true,
+  version: PACKAGE_VERSION
+});
+
+CiscoSpark.version = PACKAGE_VERSION;
+
+CiscoSpark.init = function init(attrs = {}) {
+  const config = merge({}, {
+    hydraServiceUrl: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1',
+    credentials: {
+      clientType: 'confidential'
+    },
+    device: {
+      ephemeral: true
+    },
+    storage: {
+      boundedAdapter: MemoryStoreAdapter,
+      unboundedAdapter: MemoryStoreAdapter
+    }
+  }, attrs.config);
+  return new CiscoSpark(merge({}, {config}, attrs));
+};
+
+export default CiscoSpark;

--- a/packages/node_modules/@webex/plugin-meetings/src/ciscospark.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/ciscospark.js
@@ -1,13 +1,9 @@
 import '@ciscospark/plugin-authorization';
 import '@ciscospark/internal-plugin-wdm';
 import '@ciscospark/plugin-logger';
-import '@ciscospark/plugin-messages';
-import '@ciscospark/plugin-memberships';
 import '@ciscospark/plugin-people';
 import '@ciscospark/plugin-rooms';
-import '@ciscospark/plugin-teams';
-import '@ciscospark/plugin-team-memberships';
-import '@ciscospark/plugin-webhooks';
+
 import SparkCore, {MemoryStoreAdapter} from '@ciscospark/spark-core';
 import merge from 'lodash/merge';
 

--- a/packages/node_modules/@webex/plugin-meetings/src/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/index.js
@@ -1,3 +1,9 @@
+/* eslint-env browser */
+// Any references to 'ciscospark' should be removed once this becomes an actual plugin
 import ciscospark from './ciscospark';
+import Meetings from './meetings';
 
-export default ciscospark;
+export default Meetings;
+
+window.Meetings = Meetings;
+window.ciscospark = ciscospark;

--- a/packages/node_modules/@webex/plugin-meetings/src/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/index.js
@@ -1,0 +1,3 @@
+import ciscospark from './ciscospark';
+
+export default ciscospark;

--- a/packages/node_modules/@webex/plugin-meetings/src/meetings.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meetings.js
@@ -1,0 +1,22 @@
+/**
+ * @class
+ */
+export default class Meetings {
+  /**
+   * Constructor
+   * @param {object} options
+   * @param {object} options.spark
+   */
+  constructor({spark}) {
+    this.spark = spark;
+    this.initialize();
+  }
+
+  /**
+   * Initializes the meetings plugin
+   * @returns {undefined}
+   */
+  initialize() {
+    console.log('we have initialized!');
+  }
+}

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -1,0 +1,51 @@
+const path = require('path');
+
+const dotenv = require('dotenv');
+const webpack = require('webpack');
+const merge = require('webpack-merge');
+
+dotenv.config();
+
+module.exports = merge({
+  entry: './index.js',
+  output: {
+    filename: 'bundle.js',
+    library: 'ciscospark',
+    libraryTarget: 'var',
+    path: __dirname,
+    sourceMapFilename: '[file].map'
+  },
+  devtool: 'source-map',
+  resolve: {
+    alias: {
+      node_modules: path.resolve(__dirname, '..', 'node_modules')
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: /packages\/node_modules/,
+        use: {
+          loader: 'babel-loader'
+        }
+      }
+    ]
+  },
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      CISCOSPARK_LOG_LEVEL: 'log',
+      DEBUG: '',
+      NODE_ENV: process.env.NODE_ENV || 'development',
+      CISCOSPARK_ACCESS_TOKEN: process.env.CISCOSPARK_ACCESS_TOKEN,
+      TO_PERSON: process.env.TO_PERSON,
+      // The follow environment variables are specific to our continuous
+      // integration process and should not be used in general
+      // Also, yes, CONVERSATION_SERVICE does not end in URL
+      CONVERSATION_SERVICE: process.env.CONVERSATION_SERVICE || process.env.CONVERSATION_SERVICE_URL || 'https://conv-a.wbx2.com/conversation/api/v1',
+      WDM_SERVICE_URL: process.env.WDM_SERVICE_URL || 'https://wdm-a.wbx2.com/wdm/api/v1',
+      HYDRA_SERVICE_URL: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1',
+      ATLAS_SERVICE_URL: process.env.ATLAS_SERVICE_URL || 'https://atlas-a.wbx2.com/admin/api/v1'
+    })
+  ]
+});

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -10,8 +10,6 @@ module.exports = merge({
   entry: './index.js',
   output: {
     filename: 'bundle.js',
-    library: 'ciscospark',
-    libraryTarget: 'var',
     path: __dirname,
     sourceMapFilename: '[file].map'
   },

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -1,0 +1,25 @@
+const merge = require('webpack-merge');
+
+module.exports = merge({
+  devServer: {
+    https: true,
+    disableHostCheck: true,
+    port: 8000,
+    stats: {
+      colors: true,
+      hash: false,
+      version: false,
+      timings: false,
+      assets: true,
+      chunks: false,
+      modules: false,
+      reasons: false,
+      children: false,
+      source: false,
+      errors: true,
+      errorDetails: true,
+      warnings: true,
+      publicPath: false
+    }
+  }
+});

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const merge = require('webpack-merge');
+const dotenv = require('dotenv');
+
+const baseConfig = require('./webpack.config.base.js');
+const devConfig = require('./webpack.config.dev.js');
+
+dotenv.config();
+
+module.exports = (env) => {
+  if (env && env.package) {
+    if (process.env.NODE_ENV !== 'production') {
+      const context = path.resolve(__dirname, '..', 'packages', 'node_modules', env.package);
+      return merge(baseConfig, devConfig, {
+        mode: process.env.NODE_ENV || 'development',
+        context,
+        entry: './src/index.js',
+        devServer: {
+          contentBase: path.resolve(context, 'sample')
+        }
+      });
+    }
+    return baseConfig;
+  }
+  throw new Error('Please specify a package');
+};


### PR DESCRIPTION
I created the initial scaffolding for the meetings plugin. Should be pretty self explanatory, but let me know if there's any weak spots where I can beef up the docs or comments.

All of our actual plugin code will go into `src` folder. Eventually we'll remove the `ciscospark.js` file once we hook in all the plugin code. For now, there's a `Meetings` class to get us started.
