### PR TITLE
fix(authorization): remove empty state object to clean the URL

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/src/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/src/authorization.js
@@ -12,6 +12,7 @@ import {cloneDeep, isEmpty, omit} from 'lodash';
 import uuid from 'uuid';
 
 const OAUTH2_CSRF_TOKEN = 'oauth2-csrf-token';
+const EMPTY_OBJECT_STRING = base64.encode(JSON.stringify({}));
 
 /**
  * Browser support for OAuth2. Automatically parses the URL hash for an access
@@ -120,7 +121,6 @@ const Authorization = SparkPlugin.extend({
     if (this.config.clientType === 'confidential') {
       return this.initiateAuthorizationCodeGrant(options);
     }
-
     return this.initiateImplicitGrant(options);
   },
 
@@ -241,6 +241,9 @@ const Authorization = SparkPlugin.extend({
       ].forEach((key) => Reflect.deleteProperty(location.hash, key));
       if (!isEmpty(location.hash.state)) {
         location.hash.state = base64.encode(JSON.stringify(omit(location.hash.state, 'csrf_token')));
+        if (location.hash.state === EMPTY_OBJECT_STRING) {
+          Reflect.deleteProperty(location.hash, 'state');
+        }
       }
       else {
         Reflect.deleteProperty(location.hash, 'state');

--- a/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
+++ b/packages/node_modules/@ciscospark/plugin-authorization-browser/test/unit/spec/authorization.js
@@ -296,6 +296,24 @@ browserOnly(describe)('plugin-authorization-browser', () => {
         });
       });
 
+      it('removes the state parameter when only token is present', () => {
+        const spark = makeSpark(undefined, undefined, {
+          credentials: {
+            clientType: 'confidential'
+          }
+        });
+        sinon.spy(spark.authorization, '_cleanUrl');
+        const location = {
+          hash: {
+            state: {
+              csrf_token: 'token'
+            }
+          }
+        };
+        spark.authorization._cleanUrl(location);
+        assert.equal(spark.getWindow().location.href, '');
+      });
+
       it('keeps the state parameter when it has keys', () => {
         const spark = makeSpark(undefined, undefined, {
           credentials: {


### PR DESCRIPTION
# Pull Request

## Description

Remove an encoded empty `state` from the authorized URL, cleaning it up. 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-20334

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Add test to verify clean URL. 

```
npm test -- --package @ciscospark/plugin-authorization-browser --unit
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
