### PR TITLE
test(plugin-phone): add check for if screen exists

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/screenshare.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/screenshare.js
@@ -156,7 +156,7 @@ browserOnly(describe)('plugin-phone', function () {
           }
         });
 
-        let audio, video, screen;
+        let audio, video, screenShare;
 
         assert.calledOnce(updateMediaSpy);
         let sdp = parse(updateMediaSpy.args[0][1].sdp);
@@ -168,9 +168,9 @@ browserOnly(describe)('plugin-phone', function () {
         video = sdp.media.find((m) => m.type === 'video' && !m.content);
         assert.exists(video, 'video media exists');
         assert.equal(video.direction, 'sendrecv');
-        screen = sdp.media.find((m) => m.type === 'video' && !!m.content);
-        assert.exists(screen, 'screen media exists');
-        assert.equal(screen.direction, activeScreenDirection);
+        screenShare = sdp.media.find((m) => m.type === 'video' && !!m.content);
+        assert.exists(screenShare, 'screen media exists');
+        assert.equal(screenShare.direction, activeScreenDirection);
 
         await sc.stopScreenShare();
 
@@ -184,9 +184,10 @@ browserOnly(describe)('plugin-phone', function () {
         video = sdp.media.find((m) => m.type === 'video' && !m.content);
         assert.exists(video, 'video media exists');
         assert.equal(video.direction, 'sendrecv');
-        screen = sdp.media.find((m) => m.type === 'video' && !!m.content);
-        assert.exists(screen, 'screen media exists');
-        assert.equal(screen.direction, inactiveScreenDirection);
+        // FF61 removes the content tag from the sdp after setting inactive
+        screenShare = sdp.media.find((m) => m.type === 'video' && !!m.content) || sdp.media.find((m) => m.msid === screenShare.msid);
+        assert.exists(screenShare, 'screen media exists');
+        assert.equal(screenShare.direction, inactiveScreenDirection);
 
         await sc.startApplicationShare();
 
@@ -206,9 +207,9 @@ browserOnly(describe)('plugin-phone', function () {
         video = sdp.media.find((m) => m.type === 'video' && !m.content);
         assert.exists(video, 'video media exists');
         assert.equal(video.direction, 'sendrecv');
-        screen = sdp.media.find((m) => m.type === 'video' && !!m.content);
-        assert.exists(screen, 'application screen media exists');
-        assert.equal(screen.direction, activeScreenDirection);
+        const applicationShare = sdp.media.find((m) => m.type === 'video' && !!m.content);
+        assert.exists(applicationShare, 'application screen media exists');
+        assert.equal(applicationShare.direction, activeScreenDirection);
       }));
     });
   });


### PR DESCRIPTION
# Pull Request Template

## Description

The way the sdk is currently working, when setting the share media to inactive, firefox 61 now removes our content field from the media object. I've setup the tests to handle either situation, both of which are allowed and function properly.

## Test Coverage

`npm test -- --package @ciscospark/plugin-phone --browser`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
