### PR TITLE
feat(spark-core): allow auth token on whitelisted domains

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/config.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/config.js
@@ -73,7 +73,7 @@ export default {
     preDiscoveryServices: {
       hydraServiceUrl: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1'
     },
-    // list of whitelisted domains i.e OK to pass auth token
+    // It is okay to pass the auth token to the following domains:
     whitelistedServiceDomains: [
       'wbx2.com',
       'ciscospark.com',

--- a/packages/node_modules/@ciscospark/spark-core/src/config.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/config.js
@@ -72,7 +72,13 @@ export default {
   device: {
     preDiscoveryServices: {
       hydraServiceUrl: process.env.HYDRA_SERVICE_URL || 'https://api.ciscospark.com/v1'
-    }
+    },
+    // list of whitelisted domains i.e OK to pass auth token
+    whitelistedServiceDomains: [
+      'wbx2.com',
+      'ciscospark.com',
+      'webex.com'
+    ]
   },
   payloadTransformer: {
     predicates: [],

--- a/packages/node_modules/@ciscospark/spark-core/src/interceptors/auth.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/interceptors/auth.js
@@ -61,6 +61,14 @@ export default class AuthInterceptor extends Interceptor {
       return Promise.resolve(false);
     }
 
+    // returns true if uri is in whitelistedServiceDomains and is requested
+    if (options.uri && options.runWhitelistedDomains) {
+      const matchingDomains = this.spark.config.device.whitelistedServiceDomains.filter((domain) => options.uri.includes(domain));
+      if (matchingDomains.length) {
+        return Promise.resolve(true);
+      }
+    }
+
     return this.spark.internal.device.isSpecificService('hydra', options.uri)
       .then((isHydra) => {
         if (isHydra) {

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/interceptors/auth.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/interceptors/auth.js
@@ -151,6 +151,51 @@ describe('spark-core', () => {
                 uri: 'https://not-a-service.example.com/ping'
               }))
           ]));
+
+          it('adds an auth header to urls with whitelisted domains', () => Promise.all([
+            interceptor.onRequest({
+              uri: 'https://not-a-service.wbx2.com/ping',
+              runWhitelistedDomains: true
+            })
+              .then((result) => assert.deepEqual(result, {
+                uri: 'https://not-a-service.wbx2.com/ping',
+                runWhitelistedDomains: true,
+                headers: {
+                  authorization: 'Bearer ST1'
+                }
+              })),
+            interceptor.onRequest({
+              uri: 'https://not-a-service.ciscospark.com/ping',
+              runWhitelistedDomains: true
+            })
+              .then((result) => assert.deepEqual(result, {
+                uri: 'https://not-a-service.ciscospark.com/ping',
+                runWhitelistedDomains: true,
+                headers: {
+                  authorization: 'Bearer ST1'
+                }
+              })),
+            interceptor.onRequest({
+              uri: 'https://not-a-service.webex.com/ping',
+              runWhitelistedDomains: true
+            })
+              .then((result) => assert.deepEqual(result, {
+                uri: 'https://not-a-service.webex.com/ping',
+                runWhitelistedDomains: true,
+                headers: {
+                  authorization: 'Bearer ST1'
+                }
+              })),
+            interceptor.onRequest({
+              uri: 'https://not-a-service.sample.com/ping',
+              runWhitelistedDomains: true
+            })
+              .then((result) => assert.deepEqual(result, {
+                uri: 'https://not-a-service.sample.com/ping',
+                runWhitelistedDomains: true,
+                headers: {} // doesn't add auth token for non-whitelisted domain
+              }))
+          ]));
         });
       });
 

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/interceptors/auth.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/interceptors/auth.js
@@ -151,6 +151,20 @@ describe('spark-core', () => {
                 uri: 'https://not-a-service.example.com/ping'
               }))
           ]));
+        });
+
+        describe('#requiresCredentials', () => {
+          beforeEach(() => {
+            spark.internal.device = {
+              isSpecificService() {
+                return Promise.resolve(false);
+              },
+
+              isServiceUrl() {
+                return false;
+              }
+            };
+          });
 
           it('adds an auth header to urls with whitelisted domains', () => Promise.all([
             interceptor.onRequest({


### PR DESCRIPTION
# Pull Request Template

## Description
The following changes allow passing auth token to a list of whitelisted domains.

Fixes # (issue)
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-31712

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Coverage

Added tests to ensure that the auth tokens are added in the request header only for whitelisted domains.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
