### PR TITLE
feat(media-engine-webrtc): add bandwidth limits to answer

### DIFF
--- a/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
+++ b/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
@@ -398,6 +398,8 @@ export default class WebRTCMediaEngine {
 
     // extmapFix
     newSdp = removeExtmap(newSdp);
+    // Limit bandwith
+    newSdp = limitBandwith(this.bandwidthLimit, newSdp);
 
     this.logger.debug('cleaned answer sdp:', newSdp);
     // Only accept answer if PeerConnection is in the correct state

--- a/packages/node_modules/@ciscospark/media-engine-webrtc/src/webrtc-helpers.js
+++ b/packages/node_modules/@ciscospark/media-engine-webrtc/src/webrtc-helpers.js
@@ -1,6 +1,5 @@
 // we need to import the webrtc adapter before anything else happens
 /* eslint-disable import/first */
-
 import './webrtc-adapter-adapter';
 
 import {curry, find, filter} from 'lodash';
@@ -120,13 +119,54 @@ export const ensureH264 = curry((wantsVideo, offer) => {
  * @returns {string} The modified SDP
  */
 export function limitBandwith({audioBandwidthLimit, videoBandwidthLimit}, sdp) {
-  return sdp.split('\r\n').reduce((lines, line) => {
-    lines.push(line);
-    if (line.startsWith('m=')) {
-      lines.push(`b=TIAS:${line.includes('audio') ? audioBandwidthLimit : videoBandwidthLimit}`);
+  // Set specific media bandwidths
+  let modifiedSdp = setMediaBitrate(sdp, 'audio', audioBandwidthLimit);
+  modifiedSdp = setMediaBitrate(modifiedSdp, 'video', videoBandwidthLimit);
+  return modifiedSdp;
+}
+
+/**
+ * Modifies the sdp to include media bandwidth settings
+ *
+ * Concept from:
+ * https://webrtchacks.com/limit-webrtc-bandwidth-sdp/
+ *
+ * @param {string} sdp
+ * @param {string} mediaType
+ * @param {number} bitrate
+ * @returns {string} modified sdp
+ */
+function setMediaBitrate(sdp, mediaType, bitrate) {
+  const sdpLines = sdp.split('\r\n');
+  const modifier = 'TIAS';
+  let mediaLineIndex = -1;
+  const mediaLine = `m=${mediaType}`;
+  let bitrateLineIndex = -1;
+  const bitrateLine = `b=${modifier}:${bitrate}`;
+  mediaLineIndex = sdpLines.findIndex((line) => line.startsWith(mediaLine));
+
+  // If we find a line matching “m={mediaType}”
+  if (mediaLineIndex && mediaLineIndex < sdpLines.length) {
+    // Skip the media line
+    bitrateLineIndex = mediaLineIndex + 1;
+
+    // Skip both i=* and c=* lines (bandwidths limiters have to come afterwards)
+    while (sdpLines[bitrateLineIndex].startsWith('i=') || sdpLines[bitrateLineIndex].startsWith('c=')) {
+      bitrateLineIndex += 1;
     }
-    return lines;
-  }, []).join('\r\n');
+
+    if (sdpLines[bitrateLineIndex].startsWith('b=')) {
+    // If the next line is a b=* line, replace it with our new bandwidth
+      sdpLines[bitrateLineIndex] = bitrateLine;
+    }
+    else {
+    // Otherwise insert a new bitrate line.
+      sdpLines.splice(bitrateLineIndex, 0, bitrateLine);
+    }
+  }
+
+  // Then return the updated sdp content as a string
+  return sdpLines.join('\r\n');
 }
 
 /**


### PR DESCRIPTION
# Pull Request Template

## Description

By not setting the bandwidth limit on the answer, our clients would still get the full quality video of everything being sent, thus making it seem like the bandwidth settings don't work. 

There was also a case of the bandwidth line going in before the `c=` connection line, which would get ignored as well.

Fixes # SPARK-29044

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] `npm test -- --package @ciscospark/media-engine-webrtc`


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
