### PR TITLE
fix(internal-plugin-wdm): add missing support props on device object

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -34,12 +34,19 @@ const Device = SparkPlugin.extend({
   namespace: 'Device',
 
   props: {
+    customerCompanyName: 'string',
+    customerLogoUrl: 'string',
     // deviceType doesn't have any real value, but we need to send it during
     // device refresh to make sure we don't get back an ios device url
     deviceType: 'string',
+    helpUrl: 'string',
     intranetInactivityDuration: 'number',
     intranetInactivityCheckUrl: 'string',
     modificationTime: 'string',
+    partnerCompanyName: 'string',
+    partnerLogoUrl: 'string',
+    reportingSiteDesc: 'string',
+    reportingSiteUrl: 'string',
     searchEncryptionKeyUrl: 'string',
     services: {
       // Even though @jodykstr will tell you the docs claim you don't need to
@@ -58,6 +65,9 @@ const Device = SparkPlugin.extend({
       },
       type: 'object'
     },
+    showSupportText: 'boolean',
+    supportProviderCompanyName: 'string',
+    supportProviderLogoUrl: 'string',
     url: 'string',
     userId: 'string',
     /**

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/integration/spec/device.js
@@ -25,6 +25,17 @@ describe('plugin-wdm', function () {
     describe('#register()', () => {
       it('registers a device', () => spark.internal.device.register()
         .then(() => {
+          assert.property(spark.internal.device, 'customerCompanyName');
+          assert.property(spark.internal.device, 'customerLogoUrl');
+          assert.property(spark.internal.device, 'helpUrl');
+          assert.property(spark.internal.device, 'partnerCompanyName');
+          assert.property(spark.internal.device, 'partnerLogoUrl');
+          assert.property(spark.internal.device, 'reportingSiteDesc');
+          assert.property(spark.internal.device, 'reportingSiteUrl');
+          assert.property(spark.internal.device, 'showSupportText');
+          assert.property(spark.internal.device, 'supportProviderCompanyName');
+          assert.property(spark.internal.device, 'supportProviderLogoUrl');
+
           assert.property(spark.internal.device, 'modificationTime');
           assert.property(spark.internal.device, 'services');
           assert.property(spark.internal.device, 'url');

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -93,5 +93,15 @@
     ]
   },
   "userId": "USERID",
-  "isWx2TeamMember": true
+  "isWx2TeamMember": true,
+  "customerCompanyName": "Example Customer",
+  "customerLogoUrl": "www.example.com/customer-logo",
+  "helpUrl": "www.example.com/help",
+  "partnerCompanyName": "Example Partners",
+  "partnerLogoUrl": "www.example.com/partner-logo",
+  "reportingSiteDesc": "Example Description",
+  "reportingSiteUrl": "www.example.com/report",
+  "showSupportText": false,
+  "supportProviderCompanyName": "Example Support Provider",
+  "supportProviderLogoUrl": "www.example.com/support-provider-logo"
 }


### PR DESCRIPTION
# Pull Request Template

## Description

The wdm response returns back support props such as partner/customer logos, help links, support links, etc. However this was not getting saved onto the device object and not getting passed to the web client. This PR adds those props to the device object

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
