### PR TITLE
Group call "host" field added

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/call.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/call.js
@@ -486,6 +486,15 @@ const Call = SparkPlugin.extend({
         return direction(this.locus);
       }
     },
+    /**
+     * The initiating participant in a two-party call.
+     * @deprecated The {@link Call#from} attribute will likely be replaced by
+     * the {@link Call#host}.
+     * @instance
+     * @memberof Call
+     * @readyonly
+     * @type {CallMembership}
+     */
     from: {
       deps: [
         'memberships'
@@ -575,6 +584,31 @@ const Call = SparkPlugin.extend({
        */
       fn() {
         return getStatus(this.spark, this.locus, this.previousAttributes().locus);
+      }
+    },
+    /**
+     * The host of the call
+     * Only defined if
+     * {@link PhoneConfig.enableExperimentalGroupCallingSupport} has been
+     * enabled
+     * @instance
+     * @memberof Call
+     * @readyonly
+     * @type {object}
+     */
+    host: {
+      deps: [
+        'locus'
+      ],
+      /**
+       * @private
+       * @returns {mixed}
+       */
+      fn() {
+        if (this.config.enableExperimentalGroupCallingSupport) {
+          return this.locus.host;
+        }
+        return undefined;
       }
     },
     /**

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/lib/event-expectations.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/lib/event-expectations.js
@@ -37,6 +37,11 @@ export function expectErrorEvent(ctx, msg) {
   return expectEvent(20000, 'error', ctx, msg);
 }
 
+export function expectActiveEvent(ctx, msg) {
+  return expectEvent(20000, 'active', ctx, msg);
+}
+
+
 export function expectInactiveEvent(ctx, msg) {
   return expectEvent(20000, 'inactive', ctx, msg);
 }

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/group-calling.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/group-calling.js
@@ -1,0 +1,140 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import '@ciscospark/internal-plugin-conversation';
+import '@ciscospark/plugin-phone';
+
+import {assert} from '@ciscospark/test-helper-chai';
+import CiscoSpark from '@ciscospark/spark-core';
+import testUsers from '@ciscospark/test-helper-test-users';
+import {browserOnly, handleErrorEvent} from '@ciscospark/test-helper-mocha';
+import {base64} from '@ciscospark/common';
+
+import {
+  expectActiveEvent,
+  expectCallIncomingEvent
+} from '../lib/event-expectations';
+
+browserOnly(describe)('plugin-phone', function () {
+  this.timeout(30000);
+
+  describe('Call', () => {
+    describe('with group calling enabled', () => {
+      let mccoy, spock, bones, participants;
+      beforeEach('create users and register', () => testUsers.create({count: 3})
+        .then((users) => {
+          [mccoy, spock, bones] = users;
+          participants = [mccoy, spock, bones];
+          spock.spark = new CiscoSpark({
+            credentials: {
+              authorization: spock.token
+            },
+            config: {
+              phone: {
+                enableExperimentalGroupCallingSupport: true
+              }
+            }
+          });
+
+          mccoy.spark = new CiscoSpark({
+            credentials: {
+              authorization: mccoy.token
+            },
+            config: {
+              phone: {
+                enableExperimentalGroupCallingSupport: true
+              }
+            }
+          });
+
+          return Promise.all([
+            spock.spark.phone.register(),
+            mccoy.spark.phone.register()
+          ]);
+        }));
+
+      afterEach('unregister spock and mccoy', () => Promise.all([
+        spock && spock.spark.phone.deregister()
+          // eslint-disable-next-line no-console
+          .catch((reason) => console.warn('could not disconnect spock from mercury', reason)),
+        mccoy && mccoy.spark.phone.deregister()
+          // eslint-disable-next-line no-console
+          .catch((reason) => console.warn('could not disconnect mccoy from mercury', reason))
+      ]));
+
+      describe('#from', () => {
+        describe('1:1 spaces', () => {
+          it('represents the initiating party on a 1:1', () => handleErrorEvent(spock.spark.phone.dial(mccoy.email), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => c.answer()),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.property(call.from, 'isInitiator');
+                assert.property(call.from, 'personId');
+                assert.property(call.from, 'state');
+                assert.isHydraID(call.from.personId);
+                assert.isTrue(call.from.isInitiator);
+                assert.equal(base64.decode(call.from.personId).split('/').pop(), spock.id);
+              })
+          ])));
+        });
+
+        describe('space calling', () => {
+          let conversationUrl;
+          beforeEach('create group space', () => spock.spark.internal.conversation.create({participants}).then((c) => {
+            conversationUrl = base64.encode(`ciscospark://us/ROOM/${c.id}`);
+          }));
+
+          it('is undefined for a group call', () => handleErrorEvent(spock.spark.phone.dial(conversationUrl), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => {
+                mccoy.spark.logger.info(c);
+                c.answer();
+              }),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.isUndefined(call.from);
+              })
+          ])));
+        });
+      });
+
+      describe('#host', () => {
+        describe('1:1 spaces', () => {
+          it('represents the initiating party on a 1:1', () => handleErrorEvent(spock.spark.phone.dial(mccoy.email), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => c.answer()),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.property(call.host, 'id');
+                assert.property(call.host, 'name');
+                assert.equal(call.host.id, spock.id);
+              })
+          ])));
+        });
+
+        describe('space calling', () => {
+          let conversationUrl;
+          beforeEach('create group space', () => spock.spark.internal.conversation.create({participants}).then((c) => {
+            conversationUrl = base64.encode(`ciscospark://us/ROOM/${c.id}`);
+          }));
+
+          it('is initiator of the group call', () => handleErrorEvent(spock.spark.phone.dial(conversationUrl), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => {
+                mccoy.spark.logger.info(c);
+                c.answer();
+              }),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.property(call.host, 'id');
+                assert.property(call.host, 'name');
+                assert.equal(call.host.id, spock.id);
+              })
+          ])));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a `host` field to the `Call` object for group enabled calling. This field will be the replacement for `call.from` which only works with 1:1 calls.

It also starts the tests for configs with the `enableExperimentalGroupCallingSupport` enabled.

Fixes #930 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] plugin-phone

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
