### PR TITLE
feat(plugin-phone): add roomId to call object

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/call.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/call.js
@@ -612,6 +612,31 @@ const Call = SparkPlugin.extend({
       }
     },
     /**
+     * The room id of the call
+     * Only defined if
+     * {@link PhoneConfig.enableExperimentalGroupCallingSupport} has been
+     * enabled
+     * @instance
+     * @memberof Call
+     * @readyonly
+     * @type {object}
+     */
+    roomId: {
+      deps: [
+        'locus'
+      ],
+      /**
+       * @private
+       * @returns {mixed}
+       */
+      fn() {
+        if (this.config.enableExperimentalGroupCallingSupport && this.locus.conversationUrl) {
+          return base64.encode(`ciscospark://us/ROOM/${this.locus.conversationUrl.split('/').pop()}`);
+        }
+        return undefined;
+      }
+    },
+    /**
      * Access to the remote party’s `MediaStream`.
      * @instance
      * @memberof Call

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/group-calling.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/group-calling.js
@@ -123,7 +123,6 @@ browserOnly(describe)('plugin-phone', function () {
           it('is initiator of the group call', () => handleErrorEvent(spock.spark.phone.dial(conversationUrl), (call) => Promise.all([
             expectCallIncomingEvent(mccoy.spark.phone)
               .then((c) => {
-                mccoy.spark.logger.info(c);
                 c.answer();
               }),
             expectActiveEvent(call)
@@ -131,6 +130,40 @@ browserOnly(describe)('plugin-phone', function () {
                 assert.property(call.host, 'id');
                 assert.property(call.host, 'name');
                 assert.equal(call.host.id, spock.id);
+              })
+          ])));
+        });
+      });
+
+      describe('#roomId', () => {
+        describe('1:1 spaces', () => {
+          it('represents the initiating party on a 1:1', () => handleErrorEvent(spock.spark.phone.dial(mccoy.email), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => c.answer()),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.property(call, 'roomId');
+                assert.isHydraID(call.roomId);
+              })
+          ])));
+        });
+
+        describe('space calling', () => {
+          let conversationUrl;
+          beforeEach('create group space', () => spock.spark.internal.conversation.create({participants}).then((c) => {
+            conversationUrl = base64.encode(`ciscospark://us/ROOM/${c.id}`);
+          }));
+
+          it('is initiator of the group call', () => handleErrorEvent(spock.spark.phone.dial(conversationUrl), (call) => Promise.all([
+            expectCallIncomingEvent(mccoy.spark.phone)
+              .then((c) => {
+                c.answer();
+              }),
+            expectActiveEvent(call)
+              .then(() => {
+                assert.property(call, 'roomId');
+                assert.isHydraID(call.roomId);
+                assert.equal(call.roomId, conversationUrl);
               })
           ])));
         });


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a `roomId` field to the call object when group calling is enabled.

Fixes #930 

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] plugin-phone tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
