### PR TITLE
fix(plugin-phone): add devices to memberships

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
@@ -144,8 +144,16 @@ export function participantsToCallMemberships(spark, locus) {
           membership.audioMuted = remoteAudioMuted(deviceParticipant);
           membership.videoMuted = remoteVideoMuted(deviceParticipant);
         }
+        // Remove associated device from devices map
+        devices.delete(device.url);
       }
     }
+    memberships.push(membership);
+  });
+
+  // Remaining devices are not associated with a user
+  devices.forEach((device) => {
+    const membership = participantToCallMembership(spark, locus, device);
     memberships.push(membership);
   });
 

--- a/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/state-parsers.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/state-parsers.js
@@ -1,0 +1,79 @@
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import MockSpark from '@ciscospark/test-helper-mock-spark';
+import Phone from '@ciscospark/plugin-phone';
+import AmpState from 'ampersand-state';
+import Locus from '@ciscospark/internal-plugin-locus';
+import Mercury from '@ciscospark/internal-plugin-mercury';
+import Device from '@ciscospark/internal-plugin-wdm';
+
+import {makeLocus} from '../../lib/locus';
+import {participantsToCallMemberships} from '../../../src/state-parsers';
+
+describe('plugin-phone', () => {
+  describe('state-parsers', () => {
+    let spark;
+
+    beforeEach(() => {
+      spark = new MockSpark({
+        children: {
+          device: Device,
+          locus: Locus,
+          mercury: Mercury,
+          phone: Phone,
+          people: AmpState.extend({
+            inferPersonIdFromUuid: (uuid) => uuid
+          })
+        }
+      });
+
+      sinon.stub(spark.internal.mercury, 'connect').returns(Promise.resolve());
+
+      spark.internal.device.url = 'https://example.com/devices/1';
+      spark.config.phone = {
+        audioBandwidthLimit: 64000,
+        videoBandwidthLimit: 1000000
+      };
+    });
+
+    describe('#participantsToCallMemberships', () => {
+      it('returns an array of membership objects', () => {
+        const locus = makeLocus({});
+        const memberships = participantsToCallMemberships(spark, locus);
+        assert.isTrue(Array.isArray(memberships));
+        assert.equal(memberships.length, 2);
+      });
+
+      it('associates devices to user memberships', () => {
+        const locus = makeLocus({});
+        // Add a device to locus participant object
+        locus.participants[0].devices = [{
+          id: 'a',
+          deviceType: 'IPHONE',
+          url: 'https://example.com/locus/devices/0/participant/1',
+          state: 'IDLE'
+        }];
+        const memberships = participantsToCallMemberships(spark, locus);
+        assert.isTrue(Array.isArray(memberships));
+        assert.equal(memberships.length, 2);
+      });
+
+      it('creates memberships from unassigned devices', () => {
+        const locus = makeLocus({});
+        // Add a device to locus participants
+        locus.participants.push({
+          id: 'a',
+          person: {
+            id: '88888888-4444-4444-4444-AAAAAAAAAAA1-ROOM'
+          },
+          type: 'RESOURCE_ROOM',
+          url: 'https://example.com/locus/devices/0/participant/1',
+          state: 'IDLE'
+        });
+        const memberships = participantsToCallMemberships(spark, locus);
+        assert.isTrue(Array.isArray(memberships));
+        assert.equal(memberships.length, 3);
+      });
+    });
+  });
+});


### PR DESCRIPTION
If a device is not associated to a user, it should be considered its own membership and treated as one.

This is to fix the issue of a 1:1 call to a device not registering the device as a member and the call never ends if the device hangs up first.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # SPARK-29430

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Test Coverage

- [X] plugin-phone

**Test Configuration**:
* SDK Version v1.41.0
* Node/Browser Version 8.11.3
* NPM Version 5.6.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
