### PR TITLE
feat(plugin-phone): use device status from devices to determine joined

### DIFF
--- a/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/state-parsers.js
@@ -112,7 +112,8 @@ export function joined(locus) {
  * @returns {Boolean}
  */
 export function joinedOnThisDevice(spark, locus) {
-  return joined(locus) && spark.internal.device.url === locus.self.deviceUrl;
+  return joined(locus) && locus.self.devices.some((device) =>
+    spark.internal.device.url === device.url && device.state === 'JOINED');
 }
 
 /**

--- a/packages/node_modules/@ciscospark/plugin-phone/test/lib/locus.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/lib/locus.js
@@ -42,6 +42,7 @@ export function makeLocus({
               })
             }
           ],
+          state: 'JOINED',
           url: 'https://example.com/devices/1'
         }
       ]

--- a/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/replacement.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/replacement.js
@@ -32,6 +32,7 @@ browserOnly(describe)('plugin-phone', () => {
       audioBandwidthLimit: 64000,
       videoBandwidthLimit: 1000000
     };
+    spark.internal.device.url = 'https://example.com/devices/1';
   });
 
   describe('Phone', () => {
@@ -235,7 +236,7 @@ browserOnly(describe)('plugin-phone', () => {
             .then(() => {
               assert.calledTwice(spy);
 
-              assert.equal(bricked.status, 'replaced');
+              assert.equal(replaced.status, 'replaced');
               assert.equal(bricked.internalCallId, 'https://example.com/locus/2_1');
 
               assert.equal(replaced.internalCallId, 'https://example.com/locus/1_1');

--- a/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/state-parsers.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/unit/spec/state-parsers.js
@@ -8,7 +8,7 @@ import Mercury from '@ciscospark/internal-plugin-mercury';
 import Device from '@ciscospark/internal-plugin-wdm';
 
 import {makeLocus} from '../../lib/locus';
-import {participantsToCallMemberships} from '../../../src/state-parsers';
+import {joinedOnThisDevice, participantsToCallMemberships} from '../../../src/state-parsers';
 
 describe('plugin-phone', () => {
   describe('state-parsers', () => {
@@ -34,6 +34,35 @@ describe('plugin-phone', () => {
         audioBandwidthLimit: 64000,
         videoBandwidthLimit: 1000000
       };
+    });
+
+    describe('#joinedOnThisDevice', () => {
+      it('returns true when the local device is in state JOINED', () => {
+        const locus = makeLocus({});
+        locus.self.state = 'JOINED';
+        locus.self.devices[0].state = 'JOINED';
+        assert.isTrue(joinedOnThisDevice(spark, locus));
+      });
+
+      it('returns false when the local device is not in state JOINED', () => {
+        const locus = makeLocus({});
+        locus.self.state = 'JOINED';
+        // Set current device to LEFT state
+        locus.self.devices[0].state = 'LEFT';
+        assert.isFalse(joinedOnThisDevice(spark, locus));
+      });
+
+      it('returns false when the local device is not in state JOINED and other devices are JOINED', () => {
+        const locus = makeLocus({});
+        locus.self.state = 'JOINED';
+        // Create second device
+        locus.self.devices.push(locus.self.devices[0]);
+        locus.self.devices[1].state = 'JOINED';
+        locus.self.devices[1].url = 'https://example.com/devices/2';
+        // Set current device to LEFT state
+        locus.self.devices[0].state = 'LEFT';
+        assert.isFalse(joinedOnThisDevice(spark, locus));
+      });
     });
 
     describe('#participantsToCallMemberships', () => {


### PR DESCRIPTION
Usage of `locus.self.deviceUrl` did not work properly in all scenarios.

Fixes # SPARK-37709

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Test Coverage

- [X] plugin-phone

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
