### PR TITLE
fix(i-p-conversation): auth header on key rotation

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -249,6 +249,10 @@ const Conversation = SparkPlugin.extend({
           }, omit(options, 'id', 'user', 'url'))
         };
 
+        // to prevent a 401, this will add the auth token while doing
+        // key rotation
+        params.runWhitelistedDomains = true;
+
         return Promise.resolve(user ? this.spark.internal.user.asUUID(user) : null)
           .then((userId) => {
             if (userId) {


### PR DESCRIPTION
## Description
Currently when the convo DTO does not contain the encryptionKeyUrl but still has a valid KRO, the JS sdk fails with a 401 while doing the key rotation. This change would fix the 401 during this scenario.

## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
