### PR TITLE
Update Hydra URL in test script

### DIFF
--- a/test.py
+++ b/test.py
@@ -44,10 +44,10 @@ TEST_COMMAND = 'npm test -- --package %s'
 
 SKIP_PACKAGES = [
   '@webex/bin-sauce-connect', # needs Sauce started
-  # '@webex/plugin-meetings', # no tests
-  # '@webex/test-helper-server' # no tests
-  # '@ciscospark/internal-plugin-calendar', # no tests
-  # '@ciscospark/plugin-webhooks' # no tests
+  '@webex/plugin-meetings', # no tests
+  '@webex/test-helper-server' # no tests
+  '@ciscospark/internal-plugin-calendar', # no tests
+  '@ciscospark/plugin-webhooks' # no tests
 ]
 
 def should_include_package(path_name, name):

--- a/test.py
+++ b/test.py
@@ -27,7 +27,8 @@ INT_ENV_VARS = {
   'ATLAS_SERVICE_URL': 'https://atlas-intb.ciscospark.com/admin/api/v1',
   'CONVERSATION_SERVICE': 'https://conversation-intb.ciscospark.com/conversation/api/v1',
   'ENCRYPTION_SERVICE_URL': 'https://encryption-intb.ciscospark.com/encryption/api/v1',
-  'HYDRA_SERVICE_URL': 'https://hydra-intb.ciscospark.com/v1',
+  # Do not use 'https://hydra-intb.ciscospark.com/v1' for Hydra. CI expects 'apialpha'.
+  'HYDRA_SERVICE_URL': 'https://apialpha.ciscospark.com/v1/',
   'IDBROKER_BASE_URL': 'https://idbrokerbts.webex.com',
   'IDENTITY_BASE_URL': 'https://identitybts.webex.com',
   'WDM_SERVICE_URL': 'https://wdm-intb.ciscospark.com/wdm/api/v1',

--- a/test.py
+++ b/test.py
@@ -29,6 +29,7 @@ INT_ENV_VARS = {
   'IDBROKER_BASE_URL': 'https://idbrokerbts.webex.com',
   'IDENTITY_BASE_URL': 'https://identitybts.webex.com',
   'WDM_SERVICE_URL': 'https://wdm-intb.ciscospark.com/wdm/api/v1',
+  'WHISTLER_API_SERVICE_URL': 'https://whistler.onint.ciscospark.com/api/v1',
   # Logging
   'ENABLE_VERBOSE_NETWORK_LOGGING': 'true'
 }
@@ -110,14 +111,14 @@ def main():
     writer = csv.writer(csv_file, quoting=csv.QUOTE_MINIMAL)
     writer.writerow(['Package', 'Production exit code', 'Integration exit code'])
 
-    # for package in packages:
-    #   run_env_tests(package, writer, csv_file)
+    for package in packages:
+      run_env_tests(package, writer, csv_file)
 
-    threads = [threading.Thread(target=run_env_tests, args=(package, writer, csv_file)) for package in packages]
-    for thread in threads:
-      thread.start()
-    for thread in threads:
-      thread.join()
+    # threads = [threading.Thread(target=run_env_tests, args=(package, writer, csv_file)) for package in packages]
+    # for thread in threads:
+    #   thread.start()
+    # for thread in threads:
+    #   thread.join()
 
   print('Wrote output to: %s' % OUTPUT_FILE_PATH)
   print('Done.')

--- a/test.py
+++ b/test.py
@@ -22,10 +22,12 @@ PROD_ENV_VARS = {
 }
 
 INT_ENV_VARS = {
+  # Environments
   'ACL_SERVICE_URL': 'https://acl-intb.ciscospark.com/acl/api/v1',
   'ATLAS_SERVICE_URL': 'https://atlas-intb.ciscospark.com/admin/api/v1',
   'CONVERSATION_SERVICE': 'https://conversation-intb.ciscospark.com/conversation/api/v1',
   'ENCRYPTION_SERVICE_URL': 'https://encryption-intb.ciscospark.com/encryption/api/v1',
+  'HYDRA_SERVICE_URL': 'https://hydra-intb.ciscospark.com/v1',
   'IDBROKER_BASE_URL': 'https://idbrokerbts.webex.com',
   'IDENTITY_BASE_URL': 'https://identitybts.webex.com',
   'WDM_SERVICE_URL': 'https://wdm-intb.ciscospark.com/wdm/api/v1',

--- a/test.py
+++ b/test.py
@@ -96,6 +96,17 @@ def run_env_tests(package, writer, csv_file):
   writer.writerow([package, prod_return_code, int_return_code])
   csv_file.flush()
 
+def run_tests_in_sequence(packages, writer, csv_file):
+  for package in packages:
+      run_env_tests(package, writer, csv_file)
+
+def run_tests_in_parallel(packages, writer, csv_file):
+  threads = [threading.Thread(target=run_env_tests, args=(package, writer, csv_file)) for package in packages]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
 def main():
   ciscospark_packages = get_package_names(CISCOSPARK)
   webex_packages = get_package_names(WEBEX)
@@ -114,14 +125,7 @@ def main():
     writer = csv.writer(csv_file, quoting=csv.QUOTE_MINIMAL)
     writer.writerow(['Package', 'Production exit code', 'Integration exit code'])
 
-    for package in packages:
-      run_env_tests(package, writer, csv_file)
-
-    # threads = [threading.Thread(target=run_env_tests, args=(package, writer, csv_file)) for package in packages]
-    # for thread in threads:
-    #   thread.start()
-    # for thread in threads:
-    #   thread.join()
+    run_tests_in_sequence(packages, writer, csv_file)
 
   print('Wrote output to: %s' % OUTPUT_FILE_PATH)
   print('Done.')


### PR DESCRIPTION
# Pull Request

## Description

CI/KMS was getting confused between the two equivalent, but differently named, Hydra URLs, https://hydra-intb.ciscospark.com/v1 and https://apialpha.ciscospark.com/v1/. 

Update to https://apialpha.ciscospark.com/v1/.

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-44902

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

python test.py 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
