### PR TITLE
fix(search): remove query check

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-search/src/search.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-search/src/search.js
@@ -44,10 +44,6 @@ const Search = SparkPlugin.extend({
     /* eslint max-nested-callbacks: [0] */
     options = options || {};
 
-    if (!options.query) {
-      return Promise.resolve([]);
-    }
-
     let promise = Promise.resolve();
     if (!this.spark.internal.device.searchEncryptionKeyUrl) {
       promise = this.bindSearchKey();

--- a/packages/node_modules/@ciscospark/internal-plugin-search/test/integration/spec/search.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-search/test/integration/spec/search.js
@@ -445,18 +445,44 @@ describe('plugin-search', () => {
       // }
     ];
 
+    const testDataWithAllResults = [
+      // Single word
+      // Asserts comments
+      {
+        given: {
+          user: 'spock',
+          type: ['comment']
+        },
+        expected: {
+          path: 'object.displayName',
+          results: [],
+          resultsCount: 4
+        }
+      }
+    ];
+
     function runTests(testData) {
       testData.forEach((data) => {
         const {given, expected} = data;
         const conversationLimit = given.sharedIn ? given.sharedIn.length : 'all';
         const resultLimit = given.size ? `a result limit of ${given.size}` : 'no result limit';
-        const message = util.format(`${given.user} searches ${conversationLimit} conversation(s) for "${given.query}" with ${resultLimit}. Verifies ${expected.path}.`);
+        const queryString = given.query ? `for "${given.query} "` : '';
+        const message = util.format(`${given.user} searches ${conversationLimit} conversation(s) ${queryString}with ${resultLimit}. Verifies ${expected.path}.`);
 
         it(message, () => retry(() => {
-          const params = {
-            query: given.query,
-            limit: given.size
-          };
+          let params;
+          if (given.query) {
+            params = {
+              query: given.query,
+              limit: given.size
+            };
+          }
+          else {
+            params = {
+              sharedIn: spockConversation.id,
+              type: given.type
+            };
+          }
 
           return party[given.user].spark.internal.search.search(params)
             .then((results) => {
@@ -481,6 +507,7 @@ describe('plugin-search', () => {
 
       runTests(testData);
       runTests(testDataWithResultLimit);
+      runTests(testDataWithAllResults);
     });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Description

Remove query check from search request.

This allows us to search for all items in a convo rather than having to match with a string. For example, I needed a search that returns all files in a conversation. 

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Made a search request without a query in the body. Received a successful response with all results.
- [x] Made a search request with a query in the body. Received a successful response that returned results with the query. 

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules