### PR TITLE
feat(plugin-conversation): add options param to download method

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -143,12 +143,13 @@ const Conversation = SparkPlugin.extend({
    * @param {Object} item
    * @param {Object} item.scr
    * @param {string} item.url
+   * @param {Object} options
    * @returns {Promise<File>}
    */
-  download(item) {
+  download(item, options) {
     const isEncrypted = Boolean(item.scr);
     const shunt = new EventEmitter();
-    const promise = (isEncrypted ? this.spark.internal.encryption.download(item.scr) : this._downloadUnencryptedFile(item.url))
+    const promise = (isEncrypted ? this.spark.internal.encryption.download(item.scr) : this._downloadUnencryptedFile(item.url, options))
       .on('progress', (...args) => shunt.emit('progress', ...args))
       .then((res) => readExifData(item, res))
       .then((file) => {
@@ -173,13 +174,15 @@ const Conversation = SparkPlugin.extend({
   /**
    * Downloads an unencrypted file
    * @param {string} uri
+   * @param {string} options
    * @returns {Promise<File>}
    */
-  _downloadUnencryptedFile(uri) {
-    const options = {
+  _downloadUnencryptedFile(uri, options) {
+    options = options || {};
+    Object.assign(options, {
       uri,
       responseType: 'buffer'
-    };
+    });
 
     const promise = this.request(options)
       .then((res) => res.body);

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -144,12 +144,24 @@ const Conversation = SparkPlugin.extend({
    * @param {Object} item.scr
    * @param {string} item.url
    * @param {Object} options
+   * @param {Object} options.headers
    * @returns {Promise<File>}
    */
   download(item, options) {
-    const isEncrypted = Boolean(item.scr);
+    const isEncrypted = Boolean(item.scr && item.scr.key);
     const shunt = new EventEmitter();
-    const promise = (isEncrypted ? this.spark.internal.encryption.download(item.scr) : this._downloadUnencryptedFile(item.url, options))
+    let promise;
+    if (isEncrypted) {
+      promise = this.spark.internal.encryption.download(item.scr);
+    }
+    else if (item.scr && item.scr.loc) {
+      promise = this._downloadUnencryptedFile(item.scr.loc, options);
+    }
+    else {
+      promise = this._downloadUnencryptedFile(item.url, options);
+    }
+
+    promise = promise
       .on('progress', (...args) => shunt.emit('progress', ...args))
       .then((res) => readExifData(item, res))
       .then((file) => {
@@ -174,7 +186,8 @@ const Conversation = SparkPlugin.extend({
   /**
    * Downloads an unencrypted file
    * @param {string} uri
-   * @param {string} options
+   * @param {Object} options
+   * @param {Ojbect} options.headers
    * @returns {Promise<File>}
    */
   _downloadUnencryptedFile(uri, options) {

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
@@ -64,6 +64,20 @@ describe('plugin-conversation', function () {
             .then(() => assert.called(spy));
         }));
 
+      it('downloads and decrypts a file without a scr key', () => spark.internal.conversation.download({
+        scr: {
+          loc: makeLocalUrl('/sample-image-small-one.png')
+        }
+      })
+        .then((f) => fh.isMatchingFile(f, sampleImageSmallOnePng)
+          .then((result) => assert.isTrue(result)))
+        .then(() => conversationRequestSpy.returnValues[0]
+          .then((res) => {
+            assert.property(res.options.headers, 'cisco-no-http-redirect');
+            assert.property(res.options.headers, 'spark-user-agent');
+            assert.property(res.options.headers, 'trackingid');
+          })));
+
       it('downloads and decrypts a non-encrypted file', () => spark.internal.conversation.download({url: makeLocalUrl('/sample-image-small-one.png')})
         .then((f) => fh.isMatchingFile(f, sampleImageSmallOnePng)
           .then((result) => assert.isTrue(result)))

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/test/integration/spec/get.js
@@ -38,12 +38,18 @@ describe('plugin-conversation', function () {
     describe('#download()', () => {
       let sampleImageSmallOnePng = 'sample-image-small-one.png';
 
-      let conversation;
+      let conversation, conversationRequestSpy;
       before('create conversation', () => spark.internal.conversation.create({participants})
         .then((c) => { conversation = c; }));
 
       before('fetch image fixture', () => fh.fetch(sampleImageSmallOnePng)
         .then((res) => { sampleImageSmallOnePng = res; }));
+
+      beforeEach(() => {
+        conversationRequestSpy = sinon.spy(spark.internal.conversation, 'request');
+      });
+
+      afterEach(() => conversationRequestSpy.restore());
 
       it('downloads and decrypts an encrypted file', () => spark.internal.conversation.share(conversation, [sampleImageSmallOnePng])
         .then((activity) => spark.internal.conversation.download(activity.object.files.items[0]))
@@ -60,7 +66,29 @@ describe('plugin-conversation', function () {
 
       it('downloads and decrypts a non-encrypted file', () => spark.internal.conversation.download({url: makeLocalUrl('/sample-image-small-one.png')})
         .then((f) => fh.isMatchingFile(f, sampleImageSmallOnePng)
-          .then((result) => assert.isTrue(result))));
+          .then((result) => assert.isTrue(result)))
+        .then(() => conversationRequestSpy.returnValues[0]
+          .then((res) => {
+            assert.property(res.options.headers, 'cisco-no-http-redirect');
+            assert.property(res.options.headers, 'spark-user-agent');
+            assert.property(res.options.headers, 'trackingid');
+          })));
+
+      it('downloads non-encrypted file with specific options headers', () => spark.internal.conversation.download({url: makeLocalUrl('/sample-image-small-one.png')}, {
+        headers: {
+          'cisco-no-http-redirect': null,
+          'spark-user-agent': null,
+          trackingid: null
+        }
+      })
+        .then((f) => fh.isMatchingFile(f, sampleImageSmallOnePng)
+          .then((result) => assert.isTrue(result)))
+        .then(() => conversationRequestSpy.returnValues[0]
+          .then((res) => {
+            assert.isUndefined(res.options.headers['cisco-no-http-redirect']);
+            assert.isUndefined(res.options.headers['spark-user-agent']);
+            assert.isUndefined(res.options.headers.trackingid);
+          })));
 
       it('emits download progress events for non-encrypted files', () => {
         const spy = sinon.spy();

--- a/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
@@ -7,6 +7,7 @@ import '@ciscospark/internal-plugin-lyra';
 import {assert} from '@ciscospark/test-helper-chai';
 import retry from '@ciscospark/test-helper-retry';
 import testUsers from '@ciscospark/test-helper-test-users';
+import {skipInIE} from '@ciscospark/test-helper-mocha';
 // FIXME
 // eslint-disable-next-line import/no-unresolved
 import {generateRandomString} from '@ciscospark/test-users-legacy';
@@ -149,7 +150,7 @@ describe('plugin-lyra', function () {
         }));
     });
 
-    describe('#unbindConversation()', () => {
+    skipInIE(describe)('#unbindConversation()', () => {
       before('ensure participant joined space', () => spock.spark.internal.lyra.space.join(lyraSpace)
         .then(() => lyraMachine.spark.internal.lyra.space.verifyOccupant(lyraMachine.space, spock.id))
         .then(() => spock.spark.internal.lyra.space.bindConversation(lyraSpace, conversation))
@@ -161,7 +162,7 @@ describe('plugin-lyra', function () {
         .then(({bindings}) => assert.lengthOf(bindings, 0)));
     });
 
-    describe('#deleteBinding()', () => {
+    skipInIE(describe)('#deleteBinding()', () => {
       let bindingId;
       before('ensure participant joined space', () => spock.spark.internal.lyra.space.join(lyraSpace)
         .then(() => lyraMachine.spark.internal.lyra.space.verifyOccupant(lyraMachine.space, spock.id))


### PR DESCRIPTION
# Pull Request Template

## Description

Add options param to the download method to allow custom headers for the GET request. For example, these requests are not needed in the giphy request 
```
headers: {
        'cisco-no-http-redirect': null,
        'spark-user-agent': null,
        trackingid: null
      }
```
It throws a CORS error if these are passed in FF

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] From web client, pass in options with the above headers in the description. No CORS error in FF

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
