### PR TITLE
feat(internal-plugin-wdm): add clientMessagingGiphy field to Device

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -34,6 +34,16 @@ const Device = SparkPlugin.extend({
   namespace: 'Device',
 
   props: {
+    /**
+     * Notifies the client if giphys are enabled.
+     * Currently, the values for it are:
+     * - ALLOW
+     * - BLOCK
+     * @instance
+     * @memberof Device
+     * @type {string}
+     */
+    clientMessagingGiphy: 'string',
     customerCompanyName: 'string',
     customerLogoUrl: 'string',
     // deviceType doesn't have any real value, but we need to send it during

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -94,6 +94,7 @@
   },
   "userId": "USERID",
   "isWx2TeamMember": true,
+  "clientMessagingGiphy": "ALLOW",
   "customerCompanyName": "Example Customer",
   "customerLogoUrl": "www.example.com/customer-logo",
   "helpUrl": "www.example.com/help",


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the field to Device so that org level permissions can be set to block or allow Giphys.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
