### PR TITLE
Syntax check and sanitize access token

### DIFF
--- a/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
@@ -181,37 +181,6 @@ const SparkCore = AmpState.extend({
   },
 
   /**
-   *
-   * Check if access token is correctly formated and correct if it's not
-   * Warn user if token string has errors in it
-   * @param {string} token
-   * @returns {string}
-   */
-  bearerValidator(token) {
-    if (token.includes('Bearer') && token.split(' ').length - 1 === 0) {
-      console.warn(
-        "Your access token does not have a space between 'Bearer' and the token, please add a space to it or replace it with this already fixed version:\n\n",
-        token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ')
-      );
-      console.info("Tip: You don't need to add 'Bearer' to the access_token field. The token by itself is fine");
-
-      return token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ');
-    }
-    // Allow elseIf return
-    // eslint-disable-next-line  no-else-return
-    else if (token.split(' ').length - 1 > 1) {
-      console.warn(
-        `Your access token has ${token.split(' ').length - 2} too many spaces, please use this format:\n\n`,
-        token.replace(/\s+/g, ' ')
-      );
-      console.info("Tip: You don't need to add 'Bearer' to the access_token field, the token by itself is fine");
-      return token.replace(/\s+/g, ' ');
-    }
-
-    return token.replace(/\s+/g, ' '); // Clean it anyway (just in case)
-  },
-
-  /**
    * @instance
    * @memberof SparkCore
    * @param {[type]} args
@@ -394,6 +363,35 @@ const SparkCore = AmpState.extend({
     }
 
     this.sessionId = sessionId;
+  },
+
+  /**
+   *
+   * Check if access token is correctly formated and correct if it's not
+   * Warn user if token string has errors in it
+   * @param {string} token
+   * @returns {string}
+   */
+  bearerValidator(token) {
+    if (token.includes('Bearer') && token.split(' ').length - 1 === 0) {
+      console.warn(
+        `Your access token does not have a space between 'Bearer' and the token, please add a space to it or replace it with this already fixed version:\n\n${token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ')}`
+      );
+      console.info("Tip: You don't need to add 'Bearer' to the access_token field. The token by itself is fine");
+
+      return token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ');
+    }
+    // Allow elseIf return
+    // eslint-disable-next-line  no-else-return
+    else if (token.split(' ').length - 1 > 1) {
+      console.warn(
+        `Your access token has ${token.split(' ').length - 2} too many spaces, please use this format:\n\n${token.replace(/\s+/g, ' ')}`
+      );
+      console.info("Tip: You don't need to add 'Bearer' to the access_token field, the token by itself is fine");
+      return token.replace(/\s+/g, ' ');
+    }
+
+    return token.replace(/\s+/g, ' '); // Clean it anyway (just in case)
   },
 
   /**

--- a/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
+++ b/packages/node_modules/@ciscospark/spark-core/src/spark-core.js
@@ -2,10 +2,15 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
+import {EventEmitter} from 'events';
+import util from 'util';
+
 import {proxyEvents, retry, transferEvents} from '@ciscospark/common';
 import {HttpStatusInterceptor, defaults as requestDefaults} from '@ciscospark/http-core';
 import {defaults, get, has, isFunction, isString, last, merge, omit, set, unset} from 'lodash';
 import AmpState from 'ampersand-state';
+import uuid from 'uuid';
+
 import AuthInterceptor from './interceptors/auth';
 import NetworkTimingInterceptor from './interceptors/network-timing';
 import PayloadTransformerInterceptor from './interceptors/payload-transformer';
@@ -20,9 +25,6 @@ import SparkUserAgentInterceptor from './interceptors/spark-user-agent';
 import RateLimitInterceptor from './interceptors/rate-limit';
 import config from './config';
 import {makeSparkStore} from './lib/storage';
-import util from 'util';
-import uuid from 'uuid';
-import {EventEmitter} from 'events';
 import mixinSparkCorePlugins from './lib/spark-core-plugin-mixin';
 import mixinSparkInternalCorePlugins from './lib/spark-internal-core-plugin-mixin';
 import SparkInternalCore from './spark-internal-core';
@@ -120,6 +122,9 @@ const SparkCore = AmpState.extend({
         });
 
       if (typeof get(attrs, 'credentials.access_token') === 'string') {
+        // Send access_token to get validated and corrected and then set it
+        set(attrs, 'credentials.access_token', this.bearerValidator(get(attrs, 'credentials.access_token').trim()));
+
         set(attrs, 'credentials.supertoken', attrs.credentials);
       }
     }
@@ -176,6 +181,37 @@ const SparkCore = AmpState.extend({
   },
 
   /**
+   *
+   * Check if access token is correctly formated and correct if it's not
+   * Warn user if token string has errors in it
+   * @param {string} token
+   * @returns {string}
+   */
+  bearerValidator(token) {
+    if (token.includes('Bearer') && token.split(' ').length - 1 === 0) {
+      console.warn(
+        "Your access token does not have a space between 'Bearer' and the token, please add a space to it or replace it with this already fixed version:\n\n",
+        token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ')
+      );
+      console.info("Tip: You don't need to add 'Bearer' to the access_token field. The token by itself is fine");
+
+      return token.replace('Bearer', 'Bearer ').replace(/\s+/g, ' ');
+    }
+    // Allow elseIf return
+    // eslint-disable-next-line  no-else-return
+    else if (token.split(' ').length - 1 > 1) {
+      console.warn(
+        `Your access token has ${token.split(' ').length - 2} too many spaces, please use this format:\n\n`,
+        token.replace(/\s+/g, ' ')
+      );
+      console.info("Tip: You don't need to add 'Bearer' to the access_token field, the token by itself is fine");
+      return token.replace(/\s+/g, ' ');
+    }
+
+    return token.replace(/\s+/g, ' '); // Clean it anyway (just in case)
+  },
+
+  /**
    * @instance
    * @memberof SparkCore
    * @param {[type]} args
@@ -192,7 +228,9 @@ const SparkCore = AmpState.extend({
    * @returns {Promise}
    */
   transform(direction, object) {
-    const predicates = this.config.payloadTransformer.predicates.filter((p) => !p.direction || p.direction === direction);
+    const predicates = this.config.payloadTransformer.predicates.filter(
+      (p) => !p.direction || p.direction === direction
+    );
     const ctx = {
       spark: this
     };
@@ -237,7 +275,9 @@ const SparkCore = AmpState.extend({
       };
     }
 
-    const transforms = ctx.spark.config.payloadTransformer.transforms.filter((tx) => tx.name === name && (!tx.direction || tx.direction === direction));
+    const transforms = ctx.spark.config.payloadTransformer.transforms.filter(
+      (tx) => tx.name === name && (!tx.direction || tx.direction === direction)
+    );
     // too many implicit returns on the same line is difficult to interpret
     // eslint-disable-next-line arrow-body-style
     return transforms.reduce((promise, tx) => promise.then(() => {
@@ -338,7 +378,9 @@ const SparkCore = AmpState.extend({
 
     let ints = [];
     ints = preInterceptors.reduce(addInterceptor, ints);
-    ints = Object.keys(interceptors).filter((key) => !(preInterceptors.includes(key) || postInterceptors.includes(key))).reduce(addInterceptor, ints);
+    ints = Object.keys(interceptors)
+      .filter((key) => !(preInterceptors.includes(key) || postInterceptors.includes(key)))
+      .reduce(addInterceptor, ints);
     ints = postInterceptors.reduce(addInterceptor, ints);
 
     this.request = requestDefaults({

--- a/packages/node_modules/@ciscospark/spark-core/test/unit/spec/spark-core.js
+++ b/packages/node_modules/@ciscospark/spark-core/test/unit/spec/spark-core.js
@@ -99,6 +99,29 @@ describe('Spark', () => {
       });
   });
 
+  describe('initializes with Bearer Token', () => {
+    [
+      ['initializes with a correctly formatted token', 'Bearer 1234'],
+      ['initializes and removes extra space from a token that has an extra space after Bearer', 'Bearer  1234'],
+      ['initializes and adds a space after Bearer from a token that has no spaces after Bearer', 'Bearer1234'],
+      ['initializes and trims whitespace from a token that has spaces before Bearer and after token', ' Bearer 1234 '],
+      ['initializes and removes extra space and trims whitespace from a token that has spaces before and after Bearer and after token', ' Bearer  1234 '],
+      ['initializes and trims whitspace and adds a space after Bearer from a token that has spaces before Bearer and after token and no spaces after Bearer', ' Bearer1234 ']
+    ].forEach(([msg, token]) => {
+      it(msg, () => {
+        const spark = new Spark({
+          credentials: {
+            access_token: token
+          }
+        });
+        assert.isTrue(spark.credentials.canAuthorize);
+        assert.equal(spark.credentials.supertoken.access_token, '1234');
+        assert.equal(spark.credentials.supertoken.token_type, 'Bearer');
+        assert.isTrue(spark.canAuthorize);
+      });
+    });
+  });
+
 
   it('emits the `loaded` event when the storage layer has loaded all data', () => {
     // I'd love to do this with mock spark, or at least, a mock plugin, but I


### PR DESCRIPTION
## Description

Added some syntax checking when using an [access] token during the init process to minimize errors.
Check for extra spaces and/or lack of spaces when adding `Bearer` to the access token property value, remove the potential errors caused by syntax mishaps, suggest a cleaned version and also suggest that Bearer isn't necessary (both logged to the console as warn and info respectively).

Was tested using browser samples.
Tested have not been written up for this (yet)

Fixes [SPARK-34900](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-34900)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
