### PR TITLE
Remove test to post "inactive" status

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
@@ -78,6 +78,8 @@ describe('plugin-presence', function () {
             assert.equal(presenceResponse.responses[1].subject, spock.id);
           }));
 
+      // Note: The presence service no longer accepts setting status to "inactive".
+      // Inactivity is now determined by a "last active time" of greater than 10 minutes.
       it('should receive a mercury event for a subscribed person\'s change', () => spock.spark.internal.presence.subscribe(mccoy.id)
         // 'active' status
         .then(() => Promise.all([
@@ -85,12 +87,6 @@ describe('plugin-presence', function () {
           mccoy.spark.internal.presence.setStatus('active', 1500)
         ]))
         .then(([event]) => assert.equal(event.data.status, 'active', 'mccoy presence event status should be active'))
-        // 'inactive' status
-        .then(() => Promise.all([
-          expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence inactive event'),
-          mccoy.spark.internal.presence.setStatus('inactive', 1500)
-        ]))
-        .then(([event]) => assert.equal(event.data.status, 'inactive', 'mccoy presence event status should be inactive'))
         // 'dnd' status
         .then(() => Promise.all([
           expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence dnd event'),


### PR DESCRIPTION
# Pull Request

## Description

The presence service no longer accepts setting status to "inactive". Inactivity is now determined by a "last active time" of greater than 10 minutes.

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-50100

## Type of Change

Please delete options that are not relevant.

- [x] Fix test

## Test Coverage

Test package normally. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
