### PR TITLE
fix(samples): use production urls when building samples through webpack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -454,17 +454,6 @@ ansiColor('xterm') {
 
                   sh "npm run deps:generate"
 
-                  // Define production URLs so samples work with production tokens.
-                  sh "export ACL_SERVICE_URL='https://acl-a.wbx2.com/acl/api/v1'"
-                  sh "export ATLAS_SERVICE_URL='https://atlas-a.wbx2.com/admin/api/v1'"
-                  sh "export CONVERSATION_SERVICE='https://conv-a.wbx2.com/conversation/api/v1'"
-                  sh "export ENCRYPTION_SERVICE_URL='https://encryption-a.wbx2.com'"
-                  sh "export HYDRA_SERVICE_URL='https://api.ciscospark.com/v1'"
-                  sh "export IDBROKER_BASE_URL='https://idbroker.webex.com'"
-                  sh "export IDENTITY_BASE_URL='https://identity.webex.com'"
-                  sh "export WDM_SERVICE_URL='https://wdm-a.wbx2.com/wdm/api/v1'"
-                  sh "export WHISTLER_API_SERVICE_URL='https://whistler-prod.onint.ciscospark.com/api/v1'"
-
                   // Rebuild with correct version number
                   sh 'npm run build'
                   sh "npm run build:script -- --versionNumber=${version}"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "serve:samples": "echo 'Deprecated. Please use npm run samples:serve'; npm run --silent samples:serve",
     "test:samples": "echo 'Deprecated. Please use npm run samples:test'; npm run --silent samples:test",
     "samples:build": "babel-node ./tooling/index.js build --only-samples",
-    "samples:serve": "webpack-dev-server",
+    "samples:serve": "webpack-dev-server --env=samples",
     "samples:meetings": "npm run serve:package -- --env.package @webex/plugin-meetings --env.entry ./ciscospark.js",
     "serve:package": "webpack-dev-server --config webpack/webpack.config.js --hot --inline --history-api-fallback",
     "presamples:test": "rimraf bundle.js bundle.js.map",

--- a/tooling/lib/build.js
+++ b/tooling/lib/build.js
@@ -50,9 +50,10 @@ exports.buildPackage = async function buildPackage(packageName) {
 
 exports.buildSamples = async function buildSamples() {
   await rimraf('packages/node_modules/samples/bundle*');
+
   // reminder: samples:build calls this script, not webpack, hence we must call
   // webpack here
-  await exec('webpack');
+  await exec('webpack --env=samples');
   await rename('bundle.js', 'packages/node_modules/samples/bundle.js');
   await rename('bundle.js.map', 'packages/node_modules/samples/bundle.js.map');
 


### PR DESCRIPTION
## Description

Update samples' webpack config to use production urls instead of BTS when building in the pipeline/for production

Fixes #[51238](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-51238)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
