### PR TITLE
feat(presence): enable presence for web-client

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-presence/src/config.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/src/config.js
@@ -4,5 +4,8 @@
 
 export default {
   presence: {
+    batcherWait: 50,
+    batcherMaxCalls: 50,
+    batcherMaxWait: 150
   }
 };

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence-batcher.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence-batcher.js
@@ -1,0 +1,99 @@
+/*!
+ * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {Batcher} from '@ciscospark/spark-core';
+
+/**
+ * @class
+ * @ignore
+ */
+const PresenceBatcher = Batcher.extend({
+  namespace: 'Presence',
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {HttpResponseObject} res
+   * @returns {Promise}
+   */
+  handleHttpSuccess(res) {
+    return Promise.all(res.body.statusList.map((presenceResponse) =>
+      this.handleItemSuccess(presenceResponse.subject, presenceResponse)));
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {string} item
+   * @param {Object} response
+   * @returns {Promise}
+   */
+  handleItemFailure(item, response) {
+    return this.getDeferredForResponse(item)
+      .then((defer) => {
+        defer.reject(response);
+      });
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {string} item
+   * @param {Object} response
+   * @returns {Promise}
+   */
+  handleItemSuccess(item, response) {
+    return this.getDeferredForResponse(item)
+      .then((defer) => {
+        defer.resolve(response);
+      });
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {string} id
+   * @returns {Promise<string>}
+   */
+  fingerprintRequest(id) {
+    return Promise.resolve(id);
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {string} id
+   * @returns {Promise<string>}
+   */
+  fingerprintResponse(id) {
+    return Promise.resolve(id);
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {Array} ids
+   * @returns {Promise<Array>}
+   */
+  prepareRequest(ids) {
+    return Promise.resolve(ids);
+  },
+
+  /**
+   * @instance
+   * @memberof PresenceBatcher
+   * @param {Object} subjects
+   * @returns {Promise<HttpResponseObject>}
+   */
+  submitHttpRequest(subjects) {
+    return this.spark.request({
+      method: 'POST',
+      api: 'apheleia',
+      resource: 'compositions',
+      body: {subjects}
+    });
+  }
+});
+
+export default PresenceBatcher;

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
@@ -6,6 +6,8 @@ import '@ciscospark/internal-plugin-wdm';
 
 import {SparkPlugin} from '@ciscospark/spark-core';
 
+import PresenceBatcher from './presence-batcher';
+
 const defaultSubscriptionTtl = 600;
 
 /**
@@ -14,6 +16,10 @@ const defaultSubscriptionTtl = 600;
  */
 const Presence = SparkPlugin.extend({
   namespace: 'Presence',
+
+  children: {
+    batcher: PresenceBatcher
+  },
 
   /**
    * The status object
@@ -62,28 +68,13 @@ const Presence = SparkPlugin.extend({
    * @returns {Promise<PresenceStatusesObject>} resolves with an object with key of `statusList` array
    */
   list(personIds) {
-    const batches = [];
-    const batchLimit = 50;
-
     if (!personIds || !Array.isArray(personIds)) {
       return Promise.reject(new Error('An array of person ids is required'));
     }
-    const subjects = personIds;
 
-    // Limit batches to 50 ids per request
-    for (let i = 0; i < subjects.length; i += batchLimit) {
-      batches.push(subjects.slice(i, i + batchLimit));
-    }
-
-    return Promise.all(batches.map((ids) =>
-      this.spark.request({
-        method: 'POST',
-        api: 'apheleia',
-        resource: 'compositions',
-        body: {subjects: ids}
-      })
-        .then((response) => response.body.statusList)))
-      .then((idBatches) => ({statusList: [].concat(...idBatches)}));
+    return Promise.all(personIds.map((id) =>
+      this.batcher.request(id)))
+      .then((presences) => ({statusList: presences}));
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/src/presence.js
@@ -62,18 +62,28 @@ const Presence = SparkPlugin.extend({
    * @returns {Promise<PresenceStatusesObject>} resolves with an object with key of `statusList` array
    */
   list(personIds) {
+    const batches = [];
+    const batchLimit = 50;
+
     if (!personIds || !Array.isArray(personIds)) {
       return Promise.reject(new Error('An array of person ids is required'));
     }
     const subjects = personIds;
 
-    return this.spark.request({
-      method: 'POST',
-      service: 'apheleia',
-      resource: 'compositions',
-      body: {subjects}
-    })
-      .then((response) => response.body);
+    // Limit batches to 50 ids per request
+    for (let i = 0; i < subjects.length; i += batchLimit) {
+      batches.push(subjects.slice(i, i + batchLimit));
+    }
+
+    return Promise.all(batches.map((ids) =>
+      this.spark.request({
+        method: 'POST',
+        api: 'apheleia',
+        resource: 'compositions',
+        body: {subjects: ids}
+      })
+        .then((response) => response.body.statusList)))
+      .then((idBatches) => ({statusList: [].concat(...idBatches)}));
   },
 
   /**

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
@@ -16,7 +16,7 @@ describe('plugin-presence', function () {
   describe('Presence', () => {
     let mccoy, spock;
 
-    before('create users', () => testUsers.create({count: 2})
+    beforeEach('create users', () => testUsers.create({count: 2})
       .then((users) => {
         [spock, mccoy] = users;
         spock.spark = new CiscoSpark({
@@ -31,15 +31,14 @@ describe('plugin-presence', function () {
         });
       }));
 
-    before('register with wdm', () => Promise.all([
+    beforeEach('register with wdm', () => Promise.all([
       spock.spark.internal.device.register(),
       mccoy.spark.internal.device.register()
     ]));
 
-    before('register spock with mercury', () => spock.spark.internal.mercury.connect());
+    beforeEach('register spock with mercury', () => spock.spark.internal.mercury.connect());
 
-    after('deregister spock with mercury', () => spock.spark.internal.mercury.disconnect());
-
+    afterEach('deregister spock with mercury', () => spock.spark.internal.mercury.disconnect());
 
     describe('#get()', () => {
       it('gets a person\'s status by id', () => spock.spark.internal.presence.get(mccoy.id)
@@ -101,19 +100,21 @@ describe('plugin-presence', function () {
 
       // Note: The presence service no longer accepts setting status to "inactive".
       // Inactivity is now determined by a "last active time" of greater than 10 minutes.
-      it('should receive a mercury event for a subscribed person\'s change', () => spock.spark.internal.presence.subscribe(mccoy.id)
-        // 'active' status
-        .then(() => Promise.all([
-          expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence active event'),
-          mccoy.spark.internal.presence.setStatus('active', 1500)
-        ]))
-        .then(([event]) => assert.equal(event.data.status, 'active', 'mccoy presence event status should be active'))
-        // 'dnd' status
-        .then(() => Promise.all([
-          expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence dnd event'),
-          mccoy.spark.internal.presence.setStatus('dnd', 1500)
-        ]))
-        .then(([event]) => assert.equal(event.data.status, 'dnd', 'mccoy presence event status should be dnd')));
+      it('should receive a mercury event for a subscribed person\'s change', () => {
+        spock.spark.internal.presence.subscribe(mccoy.id)
+          // 'active' status
+          .then(() => Promise.all([
+            expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence active event'),
+            mccoy.spark.internal.presence.setStatus('active', 1500)
+          ]))
+          .then(([event]) => assert.equal(event.data.status, 'active', 'mccoy presence event status should be active'))
+          // 'dnd' status
+          .then(() => Promise.all([
+            expectEvent(10000, 'event:apheleia.subscription_update', spock.spark.internal.mercury, 'spock should get the presence dnd event'),
+            mccoy.spark.internal.presence.setStatus('dnd', 1500)
+          ]))
+          .then(([event]) => assert.equal(event.data.status, 'dnd', 'mccoy presence event status should be dnd'));
+      });
     });
 
     describe('#unsubscribe', () => {

--- a/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-presence/test/integration/spec/presence.js
@@ -9,6 +9,7 @@ import {assert} from '@ciscospark/test-helper-chai';
 import CiscoSpark from '@ciscospark/spark-core';
 import testUsers from '@ciscospark/test-helper-test-users';
 import {expectEvent} from '@ciscospark/test-helper-mocha';
+import sinon from '@ciscospark/test-helper-sinon';
 
 describe('plugin-presence', function () {
   this.timeout(10000);
@@ -57,6 +58,26 @@ describe('plugin-presence', function () {
           assert.property(presenceResponse.statusList[1], 'subject');
           assert.equal(presenceResponse.statusList[1].subject, spock.id);
         }));
+
+      describe('batching of presence requests', () => {
+        let batchTestUsers;
+
+        beforeEach('create more users', () => testUsers.create({count: 6})
+          .then((users) => {
+            batchTestUsers = users;
+          }));
+
+        it('executes network requests for max limit', () => {
+          spock.spark.internal.presence.config.batcherMaxCalls = 2;
+          sinon.spy(spock.spark.internal.presence.batcher, 'submitHttpRequest');
+          return spock.spark.internal.presence.list(batchTestUsers.map((user) => user.id))
+            .then((presenceResponse) => {
+              assert.equal(presenceResponse.statusList.length, 6);
+              assert.calledThrice(spock.spark.internal.presence.batcher.submitHttpRequest);
+              spock.spark.internal.presence.batcher.submitHttpRequest.restore();
+            });
+        });
+      });
     });
 
     describe('#subscribe', () => {

--- a/packages/node_modules/@webex/recipe-private-web-client/src/index.js
+++ b/packages/node_modules/@webex/recipe-private-web-client/src/index.js
@@ -13,6 +13,7 @@ import '@ciscospark/internal-plugin-flag';
 import '@ciscospark/plugin-logger';
 import '@ciscospark/internal-plugin-mercury';
 import '@ciscospark/internal-plugin-metrics';
+import '@ciscospark/internal-plugin-presence';
 import '@ciscospark/internal-plugin-search';
 import '@ciscospark/internal-plugin-support';
 import '@ciscospark/internal-plugin-team';


### PR DESCRIPTION
# Pull Request Template

## Description

Enabled presence module for web-client use.
Added batching handling to presence list function.

Previously, web-client was making the apheleia requests itself. We're now going to rely on the sdk instead.

Apheleia's list and subsribe requests have a cap of 50 ids per request. Subscribe() already handles more than 50 ids with batches. Copied that logic over to list().

Fixes # (issue)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verified that web-client sees presences module
- [x] Passed existing test suites
- [x] Tested on web-client with request of less than 50 ids
- [x] Verified response is a single array of less than 50 ids
- [x] Tested on web-client with request of more than 50 ids
- [x] Verified response is a single array of more than 50 ids

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules