### PR TITLE
Fix skipping IE 11 Lyra tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,10 +13,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "browsers": [
-          "last 2 versions",
-          "safari >= 7"
-        ]
+        "browsers": ["safari >= 7", "ie >= 11", "> 1%"]
       }
     }]
   ],

--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,7 @@
           "not dead",
           "ie >= 11" // Office 365 support
         ],
-        "node": "6"
+        "node": "6.0"
       }
     }]
   ],

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "transform-runtime",
     "./tooling/babel-plugin-inject-package-version",
     ["babel-plugin-transform-builtin-extend", {
         "globals": ["Error"]
@@ -8,12 +9,16 @@
     "transform-class-properties",
     "transform-export-extensions",
     "lodash",
-    "transform-runtime"
   ],
   "presets": [
     ["env", {
       "targets": {
-        "browsers": ["safari >= 7", "ie >= 11", "> 1%"]
+        "browsers": [
+          ">0.25%",
+          "not dead",
+          "ie >= 11" // Office 365 support
+        ],
+        "node": "6"
       }
     }]
   ],

--- a/karma-ng.conf.js
+++ b/karma-ng.conf.js
@@ -78,6 +78,8 @@ function makeConfig(packageName, argv) {
 
     customLaunchers: launchers,
 
+    failOnEmptyTestSuite: false,
+
     files,
 
     frameworks: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12386,6 +12386,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -14954,7 +14959,8 @@
         "commenting": "1.0.5",
         "lodash": "4.17.11",
         "magic-string": "0.25.1",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.1",
+        "moment": "2.23.0"
       },
       "dependencies": {
         "lodash": {
@@ -14969,11 +14975,6 @@
           "requires": {
             "sourcemap-codec": "^1.4.1"
           }
-        },
-        "moment": {
-          "version": "2.22.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-          "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "backoff": "^2.5.0",
     "blob": "0.0.5",
     "body-parser": "^1.17.2",
-    "bowser": "^1.6.0",
+    "bowser": "1.9.4",
     "browser-saveas": "^1.0.1",
     "browserify": "^15.2.0",
     "browserify-istanbul": "^3.0.1",

--- a/packages/node_modules/@ciscospark/common/test/unit/spec/exception.js
+++ b/packages/node_modules/@ciscospark/common/test/unit/spec/exception.js
@@ -2,8 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-const browser = require('bowser');
-
+import bowser from 'bowser';
 import {Exception} from '@ciscospark/common';
 import {assert} from '@ciscospark/test-helper-chai';
 
@@ -85,7 +84,7 @@ describe('common', () => {
     });
 
     // Skip in IE.
-    (browser.ie ? it.skip : it)('includes the exception class name when stringified', () => {
+    (bowser.msie ? it.skip : it)('includes the exception class name when stringified', () => {
       class MyException extends Exception {
         static defaultMessage = 'My exception occurred';
       }

--- a/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
@@ -2,8 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-const browser = require('bowser');
-
+import bowser from 'bowser';
 import '@ciscospark/internal-plugin-lyra';
 import {assert} from '@ciscospark/test-helper-chai';
 import retry from '@ciscospark/test-helper-retry';
@@ -158,7 +157,7 @@ describe('plugin-lyra', function () {
         .then(({bindings}) => assert.lengthOf(bindings, 1)));
 
       // Skip this feature in IE. We do not support it at this time.
-      (browser.ie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.unbindConversation(lyraSpace, conversation)
+      (bowser.msie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.unbindConversation(lyraSpace, conversation)
         .then(() => spock.spark.internal.lyra.space.getCurrentBindings(lyraMachine.space))
         .then(({bindings}) => assert.lengthOf(bindings, 0)));
     });
@@ -175,7 +174,7 @@ describe('plugin-lyra', function () {
         }));
 
       // Skip this feature in IE. We do not support it at this time.
-      (browser.ie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.deleteBinding(lyraMachine.space, {kmsResourceObjectUrl: conversation.kmsResourceObjectUrl, bindingId})
+      (bowser.msie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.deleteBinding(lyraMachine.space, {kmsResourceObjectUrl: conversation.kmsResourceObjectUrl, bindingId})
         .then(() => spock.spark.internal.lyra.space.getCurrentBindings(lyraMachine.space))
         .then(({bindings}) => assert.lengthOf(bindings, 0)));
     });

--- a/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-lyra/test/integration/spec/space.js
@@ -157,7 +157,7 @@ describe('plugin-lyra', function () {
         .then(() => spock.spark.internal.lyra.space.getCurrentBindings(lyraMachine.space))
         .then(({bindings}) => assert.lengthOf(bindings, 1)));
 
-      // Skip this feature in IE. We do support it at this time.
+      // Skip this feature in IE. We do not support it at this time.
       (browser.ie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.unbindConversation(lyraSpace, conversation)
         .then(() => spock.spark.internal.lyra.space.getCurrentBindings(lyraMachine.space))
         .then(({bindings}) => assert.lengthOf(bindings, 0)));
@@ -174,7 +174,7 @@ describe('plugin-lyra', function () {
           bindingId = bindings[0].bindingUrl.split('/').pop();
         }));
 
-      // Skip this feature in IE. We do support it at this time.
+      // Skip this feature in IE. We do not support it at this time.
       (browser.ie ? it.skip : it)('removes the binding between conversation and lyra space', () => spock.spark.internal.lyra.space.deleteBinding(lyraMachine.space, {kmsResourceObjectUrl: conversation.kmsResourceObjectUrl, bindingId})
         .then(() => spock.spark.internal.lyra.space.getCurrentBindings(lyraMachine.space))
         .then(({bindings}) => assert.lengthOf(bindings, 0)));

--- a/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
+++ b/packages/node_modules/@ciscospark/media-engine-webrtc/src/engine.js
@@ -1,3 +1,4 @@
+import bowser from 'bowser';
 import {debounce} from 'lodash-decorators';
 import {nonenumerable} from 'core-decorators';
 import {make as makeTemplateContainer, oneFlight, tap, whileInFlight} from '@ciscospark/common';
@@ -6,7 +7,6 @@ import Events from 'ampersand-events';
 import {defaults} from 'lodash';
 import {parse} from 'sdp-transform';
 import grammar from 'sdp-transform/lib/grammar';
-import browser from 'bowser';
 
 import {
   ensureH264,
@@ -497,7 +497,7 @@ export default class WebRTCMediaEngine {
           // We remove the track from localMediaStream, and disable on PeerConnection
           this.logger.info(`muting existing ${kind} track from localMediaStream`);
           const sender = this.pc.getSenders().find((s) => s.track === track);
-          if (!browser.firefox) {
+          if (!bowser.firefox) {
             this.localMediaStream.removeTrack(track);
           }
           if (sender) {
@@ -506,7 +506,7 @@ export default class WebRTCMediaEngine {
             track.enabled = false;
             // We must remove sender track from PC when muting
             // browsers will still create SDP media field if we don't remote the track
-            if (!browser.firefox) {
+            if (!bowser.firefox) {
               this.pc.removeTrack(sender);
             }
           }

--- a/packages/node_modules/@ciscospark/media-engine-webrtc/test/unit/spec/engine.js
+++ b/packages/node_modules/@ciscospark/media-engine-webrtc/test/unit/spec/engine.js
@@ -1,6 +1,6 @@
 /* global step: false */
 
-import browser from 'bowser';
+import bowser from 'bowser';
 import 'mocha-steps';
 import {assert} from '@ciscospark/test-helper-chai';
 import {browserOnly, expectEvent, firefoxOnly, handleErrorEvent} from '@ciscospark/test-helper-mocha';
@@ -146,7 +146,7 @@ browserOnly(describe)('media-engine-webrtc', function () {
               const brokenInChrome = audioStart !== 'inactive' && audioEnd === 'inactive'
                 && videoStart === 'recvonly' && videoEnd.includes('send');
 
-              const shouldSkip = (browser.chrome && (flakyInChrome || brokenInChrome)) || (browser.firefox && brokenInFirefox);
+              const shouldSkip = (bowser.chrome && (flakyInChrome || brokenInChrome)) || (bowser.firefox && brokenInFirefox);
 
               // See `renegotiation-support.md` for renegotiation and ontrack table
 
@@ -256,9 +256,9 @@ browserOnly(describe)('media-engine-webrtc', function () {
                   // so we should not renegotiate when transitioning to enable recv
                   expectNewRemoteTrackOnTransition = expectNewRemoteTrackOnTransition
                     || !audioStart.includes('recv') && audioEnd.includes('recv')
-                      && !(browser.firefox && audioStart === 'sendonly' && audioEnd.includes('recv'))
+                      && !(bowser.firefox && audioStart === 'sendonly' && audioEnd.includes('recv'))
                     || !videoStart.includes('recv') && videoEnd.includes('recv')
-                      && !(browser.firefox && videoStart === 'sendonly' && videoEnd.includes('recv'));
+                      && !(bowser.firefox && videoStart === 'sendonly' && videoEnd.includes('recv'));
 
                   expectToRenegotiateOnTransition = expectNewRemoteTrackOnTransition
                     || !audioStart.includes('send') && audioEnd.includes('send')
@@ -276,20 +276,20 @@ browserOnly(describe)('media-engine-webrtc', function () {
                         .then((offerSdp) => {
                           // When transitioning to inactive after a renegotiation, FF does not set
                           // correct direction on sdp so we skip the assertions
-                          if (!browser.firefox || audioEnd !== 'inactive') {
+                          if (!bowser.firefox || audioEnd !== 'inactive') {
                             assertOffer('audio', audioEnd, audioStart, offerSdp);
                           }
-                          if (!browser.firefox || videoEnd !== 'inactive') {
+                          if (!bowser.firefox || videoEnd !== 'inactive') {
                             assertOffer('video', videoEnd, videoStart, offerSdp);
                           }
                           return offerSdp;
                         })
                         .then(simulateAnswer)
                         .then((answerSdp) => {
-                          if (!browser.firefox || audioEnd !== 'inactive') {
+                          if (!bowser.firefox || audioEnd !== 'inactive') {
                             assertAnswer('audio', audioEnd, audioStart, answerSdp);
                           }
-                          if (!browser.firefox || videoEnd !== 'inactive') {
+                          if (!bowser.firefox || videoEnd !== 'inactive') {
                             assertAnswer('video', videoEnd, videoStart, answerSdp);
                           }
                           return answerSdp;
@@ -301,7 +301,7 @@ browserOnly(describe)('media-engine-webrtc', function () {
                       assertLocalMedia(engine, audioEnd, videoEnd);
                       // Firefox transitions from sendonly to recv that trigger renegotiation
                       // generates extra receiver tracks. We ignore those changes for now.
-                      if (!browser.firefox
+                      if (!bowser.firefox
                         || !expectToRenegotiateOnTransition
                         || ((videoStart !== 'sendonly' || !videoEnd.includes('recv'))
                           && (audioStart !== 'sendonly' || !audioEnd.includes('recv')))) {
@@ -343,7 +343,7 @@ browserOnly(describe)('media-engine-webrtc', function () {
                   // when we add recv back, we must trigger renegotiation to get
                   // the new track.
                   expectNewRemoteTrackOnReturn = expectNewRemoteTrackOnReturn
-                    || browser.chrome
+                    || bowser.chrome
                       && (!audioEnd.includes('recv') && audioStart.includes('recv')
                         || !videoEnd.includes('recv') && videoStart.includes('recv'))
                       && expectToRenegotiateOnTransition;
@@ -380,7 +380,7 @@ browserOnly(describe)('media-engine-webrtc', function () {
                       assertLocalMedia(engine, audioStart, videoStart);
                       // Firefox transitions from sendonly to recv that trigger renegotiation
                       // generates extra receiver tracks. We ignore those changes for now.
-                      if (!browser.firefox
+                      if (!bowser.firefox
                         || !expectToRenegotiateOnTransition
                         || ((videoStart !== 'sendonly' || !videoEnd.includes('recv'))
                           && (audioStart !== 'sendonly' || !audioEnd.includes('recv')))) {

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/media-state-controls.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/media-state-controls.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import browser from 'bowser';
+import bowser from 'bowser';
 import {boolToStatus, remoteParticipant} from '@ciscospark/plugin-phone';
 import {assert} from '@ciscospark/test-helper-chai';
 import sinon from '@ciscospark/test-helper-sinon';
@@ -160,7 +160,7 @@ browserOnly(describe)('plugin-phone', function () {
           // TODO Chrome fails at setting remote answer sdp when going from inactive
           // to active and back to inactive, skipping test for now until core issue
           // is found. Could be locus or Chrome bug
-          (browser.chrome ? it.skip : it)('starts receiving audio and stops receiving audio', () => {
+          (bowser.chrome ? it.skip : it)('starts receiving audio and stops receiving audio', () => {
             const call = spock.spark.phone.dial(mccoy.email, {
               constraints: {
                 audio: false,
@@ -236,7 +236,7 @@ browserOnly(describe)('plugin-phone', function () {
           // TODO Chrome fails at setting remote answer sdp when going from inactive
           // to active and back to inactive, skipping test for now until core issue
           // is found. Could be locus or Chrome bug
-          (browser.chrome ? it.skip : it)('starts receiving video and stops receiving video', () => {
+          (bowser.chrome ? it.skip : it)('starts receiving video and stops receiving video', () => {
             const call = spock.spark.phone.dial(mccoy.email, {
               constraints: {
                 audio: true,
@@ -350,7 +350,7 @@ browserOnly(describe)('plugin-phone', function () {
           // TODO Chrome fails at setting remote answer sdp when going from inactive
           // to active and back to inactive, skipping test for now until core issue
           // is found. Could be locus or Chrome bug
-          (browser.chrome ? it.skip : it)('starts sending audio and stops sending audio', () => {
+          (bowser.chrome ? it.skip : it)('starts sending audio and stops sending audio', () => {
             const call = spock.spark.phone.dial(mccoy.email, {
               constraints: {
                 audio: false,
@@ -491,7 +491,7 @@ browserOnly(describe)('plugin-phone', function () {
           // TODO Chrome fails at setting remote answer sdp when going from inactive
           // to active and back to inactive, skipping test for now until core issue
           // is found. Could be locus or Chrome bug
-          (browser.chrome ? it.skip : it)('starts sending video and stops sending video', () => {
+          (bowser.chrome ? it.skip : it)('starts sending video and stops sending video', () => {
             const call = spock.spark.phone.dial(mccoy.email, {
               constraints: {
                 audio: true,

--- a/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/screenshare.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/test/integration/spec/screenshare.js
@@ -3,8 +3,7 @@
  */
 
 import '@ciscospark/plugin-phone';
-
-import browser from 'bowser';
+import bowser from 'bowser';
 import {assert} from '@ciscospark/test-helper-chai';
 import sinon from '@ciscospark/test-helper-sinon';
 import CiscoSpark from '@ciscospark/spark-core';
@@ -145,8 +144,8 @@ browserOnly(describe)('plugin-phone', function () {
 
         // Firefox > 59 initialiates sendonly media as sendrecv
         // Monitor updates to adapter and FF. This will fail once the bug has been fixed
-        const activeScreenDirection = browser.firefox ? 'sendrecv' : 'sendonly';
-        const inactiveScreenDirection = browser.firefox ? 'recvonly' : 'inactive';
+        const activeScreenDirection = bowser.firefox ? 'sendrecv' : 'sendonly';
+        const inactiveScreenDirection = bowser.firefox ? 'recvonly' : 'inactive';
 
         await sc.startScreenShare();
 

--- a/packages/node_modules/@ciscospark/test-helper-mocha/src/index.js
+++ b/packages/node_modules/@ciscospark/test-helper-mocha/src/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-const browser = require('bowser');
+const bowser = require('bowser');
 
 /**
  * Indicates if we're running in node
@@ -28,7 +28,7 @@ function inBrowser() {
  * @private
  */
 function inFirefox() {
-  return browser.firefox;
+  return bowser.firefox;
 }
 
 /**

--- a/tooling/lib/test/karma.js
+++ b/tooling/lib/test/karma.js
@@ -72,10 +72,26 @@ async function run(cfg) {
       watchSauce(server, cfg);
     }
 
+    server.on('browser_error', debugBrowserError);
     server.start(cfg);
   });
 
   return result === 0;
+}
+
+/**
+ * Debug browser errors to quickly discern IE11 errors.
+ * @see http://karma-runner.github.io/3.0/dev/public-api.html
+ * @param {Object} browser The browser instance
+ * @param {Object} error The error that occurred
+ */
+function debugBrowserError(browser, error) {
+  let errorType = 'error';
+  if (error.message) {
+    errorType = error.message.split('\n')[0].toLowerCase();
+  }
+  const browserName = browser.name.toLowerCase();
+  debug(`${errorType} on ${browserName}`);
 }
 
 /**


### PR DESCRIPTION
# Pull Request 

## Description

Upgrades `bowser` to appropriately skip IE 11 Lyra tests. 

Fixes https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-62550

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> New and existing unit tests pass locally with my changes

Existing failing tests have not been fixed. They are [documented](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-42359?filter=18897). 