### PR TITLE
fix(metrics): allow context through the whitelist

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/src/metrics.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/src/metrics.js
@@ -3,10 +3,11 @@
  */
 
 import {SparkPlugin} from '@ciscospark/spark-core';
+import {deprecated} from '@ciscospark/common';
+
 import Batcher from './batcher';
 import ClientMetricsBatcher from './client-metrics-batcher';
 import CallDiagnosticEventsBatcher from './call-diagnostic-events-batcher';
-import {deprecated} from '@ciscospark/common';
 
 const Metrics = SparkPlugin.extend({
   children: {
@@ -44,21 +45,24 @@ const Metrics = SparkPlugin.extend({
     if (props.type) {
       payload.type = props.type;
     }
+    if (props.context) {
+      payload.context = props.context;
+    }
+
     payload.timestamp = Date.now();
+
     if (preLoginId) {
       const _payload = {
-        metrics: [
-          payload
-        ]
+        metrics: [payload]
       };
       // Do not batch these because pre-login events occur during onboarding, so we will be partially blind
       // to users' progress through the reg flow if we wait to persist pre-login metrics for people who drop off because
       // their metrics will not post from a queue flush in time
       return this.postPreLoginMetric(_payload, preLoginId);
     }
+
     return this.clientMetricsBatcher.request(payload);
   },
-
 
   /**
    * Issue request to alias a user's pre-login ID with their CI UUID
@@ -81,8 +85,8 @@ const Metrics = SparkPlugin.extend({
   },
 
   postPreLoginMetric(payload, preLoginId) {
-    return this.spark.credentials.getClientToken()
-      .then((token) => this.request({
+    return this.spark.credentials.getClientToken().then((token) =>
+      this.request({
         method: 'POST',
         api: 'metrics',
         resource: 'clientmetrics-prelogin',
@@ -101,7 +105,6 @@ const Metrics = SparkPlugin.extend({
     };
     return this.callDiagnosticEventsBatcher.request(event);
   }
-
 });
 
 export default Metrics;

--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -33,7 +33,8 @@ describe('plugin-metrics', () => {
       },
       metricName: eventName,
       test: 'this field should not be included in final payload',
-      type: 'behavioral'
+      type: 'behavioral',
+      context: {}
     };
     const transformedProps = {
       fields: {
@@ -48,9 +49,7 @@ describe('plugin-metrics', () => {
     };
     const preLoginId = '1b90cf5e-27a6-41aa-a208-1f6eb6b9e6b6';
     const preLoginProps = {
-      metrics: [
-        transformedProps
-      ]
+      metrics: [transformedProps]
     };
     const mockCallDiagnosticEvent = {
       originTime: {
@@ -106,6 +105,7 @@ describe('plugin-metrics', () => {
             assert.property(metric, 'env');
             assert.property(metric, 'time');
             assert.property(metric, 'version');
+            assert.property(metric, 'context');
 
             assert.equal(metric.key, 'testMetric');
             assert.equal(metric.version, spark.version);
@@ -200,8 +200,8 @@ describe('plugin-metrics', () => {
     });
 
     describe('#aliasUser()', () => {
-      it('returns an HttpResponse object', () => metrics.aliasUser(preLoginId)
-        .then(() => {
+      it('returns an HttpResponse object', () =>
+        metrics.aliasUser(preLoginId).then(() => {
           assert.calledOnce(spark.request);
           const req = spark.request.args[0][0];
           const params = req.qs;

--- a/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-metrics/test/unit/spec/metrics.js
@@ -33,8 +33,7 @@ describe('plugin-metrics', () => {
       },
       metricName: eventName,
       test: 'this field should not be included in final payload',
-      type: 'behavioral',
-      context: {}
+      type: 'behavioral'
     };
     const transformedProps = {
       fields: {
@@ -105,7 +104,6 @@ describe('plugin-metrics', () => {
             assert.property(metric, 'env');
             assert.property(metric, 'time');
             assert.property(metric, 'version');
-            assert.property(metric, 'context');
 
             assert.equal(metric.key, 'testMetric');
             assert.equal(metric.version, spark.version);
@@ -147,7 +145,8 @@ describe('plugin-metrics', () => {
         it('submits a metric to clientmetrics', () => {
           const testPayload = {
             tags: {success: true},
-            fields: {perceivedDurationInMillis: 314}
+            fields: {perceivedDurationInMillis: 314},
+            context: {}
           };
           const date = Date.now();
           const promise = metrics.submitClientMetrics('test', testPayload);
@@ -163,6 +162,7 @@ describe('plugin-metrics', () => {
               assert.property(metric, 'tags');
               assert.property(metric, 'fields');
               assert.property(metric, 'timestamp');
+              assert.property(metric, 'context');
 
               assert.equal(metric.timestamp, date);
               assert.equal(metric.metricName, 'test');


### PR DESCRIPTION
# Pull Request Template
We currently whitelist which properties we send to metrics-a. This allow us to send "context" which is a required field when piping metrics through segment A to segment. 

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
