### PR TITLE
Do not include plugin-meetings by default

### DIFF
--- a/packages/node_modules/ciscospark/src/ciscospark.js
+++ b/packages/node_modules/ciscospark/src/ciscospark.js
@@ -14,7 +14,6 @@ require('@ciscospark/plugin-authorization');
 require('@ciscospark/internal-plugin-wdm');
 require('@ciscospark/plugin-logger');
 require('@ciscospark/plugin-phone');
-require('@webex/plugin-meetings');
 require('@ciscospark/plugin-messages');
 require('@ciscospark/plugin-memberships');
 require('@ciscospark/plugin-people');


### PR DESCRIPTION
# Pull Request 

## Description

Remove `plugin-meetings` until it replaces `plugin-phone`, e.g., samples, tests. 

Fixes NA

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
