### PR TITLE
Feat membership events

### DIFF
--- a/packages/node_modules/@ciscospark/common/src/constants.js
+++ b/packages/node_modules/@ciscospark/common/src/constants.js
@@ -1,6 +1,7 @@
-export const API_ACTIVITY_TYPE = {
-  REPLY: 'reply'
+export const WEBEX_EVENT = {
+  TEAMS_ACTIVITY: 'event:conversation.activity'
 };
+
 
 export const API_ACTIVITY_VERB = {
   ACKNOWLEDGE: 'acknowledge',
@@ -10,6 +11,28 @@ export const API_ACTIVITY_VERB = {
   LEAVE: 'leave',
   ADD_MODERATOR: 'assignModerator',
   REMOVE_MODERATOR: 'unassignModerator'
+};
+
+export const SDK_EVENT = {
+  CREATED: 'created',
+  DELETED: 'deleted',
+  UPDATED: 'updated',
+  SEEN: 'seen'
+};
+
+export const SDK_EVENT_OWNER = {
+  CREATOR: 'creator',
+  ORG: 'org'
+};
+
+export const SDK_EVENT_STATUS = {
+  ACTIVE: 'active',
+  DISABLED: 'disabled'
+};
+
+export const SDK_EVENT_RESOURCE = {
+  MEMBERSHIPS: 'memberships',
+  MESSAGES: 'messages'
 };
 
 export const hydraTypes = {

--- a/packages/node_modules/@ciscospark/common/src/constants.js
+++ b/packages/node_modules/@ciscospark/common/src/constants.js
@@ -2,6 +2,16 @@ export const WEBEX_EVENT = {
   TEAMS_ACTIVITY: 'event:conversation.activity'
 };
 
+export const WEBEX_SPACE_TYPE = {
+  DIRECT: 'direct',
+  GROUP: 'group'
+};
+
+export const API_ACTIVITY_FIELD = {
+  ACTOR: 'actor',
+  OBJECT: 'object',
+  TARGET: 'target'
+};
 
 export const API_ACTIVITY_VERB = {
   ACKNOWLEDGE: 'acknowledge',
@@ -10,7 +20,8 @@ export const API_ACTIVITY_VERB = {
   ADD: 'add',
   LEAVE: 'leave',
   ADD_MODERATOR: 'assignModerator',
-  REMOVE_MODERATOR: 'unassignModerator'
+  REMOVE_MODERATOR: 'unassignModerator',
+  HIDE: 'hide'
 };
 
 export const SDK_EVENT = {

--- a/packages/node_modules/@ciscospark/common/src/constants.js
+++ b/packages/node_modules/@ciscospark/common/src/constants.js
@@ -5,12 +5,18 @@ export const API_ACTIVITY_TYPE = {
 export const API_ACTIVITY_VERB = {
   ACKNOWLEDGE: 'acknowledge',
   POST: 'post',
-  SHARE: 'share'
+  SHARE: 'share',
+  ADD: 'add',
+  LEAVE: 'leave',
+  ADD_MODERATOR: 'assignModerator',
+  REMOVE_MODERATOR: 'unassignModerator'
 };
 
 export const hydraTypes = {
   CONTENT: 'CONTENT',
+  MEMBERSHIP: 'MEMBERSHIP',
   MESSAGE: 'MESSAGE',
+  ORGANIZATION: 'ORGANIZATION',
   PEOPLE: 'PEOPLE',
   ROOM: 'ROOM',
   TEAM: 'TEAM'

--- a/packages/node_modules/@ciscospark/common/src/index.js
+++ b/packages/node_modules/@ciscospark/common/src/index.js
@@ -24,6 +24,8 @@ export {default as inBrowser} from './in-browser';
 export {
   hydraTypes,
   WEBEX_EVENT,
+  WEBEX_SPACE_TYPE,
+  API_ACTIVITY_FIELD,
   API_ACTIVITY_VERB,
   SDK_EVENT,
   SDK_EVENT_OWNER,

--- a/packages/node_modules/@ciscospark/common/src/index.js
+++ b/packages/node_modules/@ciscospark/common/src/index.js
@@ -22,9 +22,13 @@ export {default as Exception} from './exception';
 export {default as deprecated} from './deprecated';
 export {default as inBrowser} from './in-browser';
 export {
+  hydraTypes,
+  WEBEX_EVENT,
   API_ACTIVITY_VERB,
-  API_ACTIVITY_TYPE,
-  hydraTypes
+  SDK_EVENT,
+  SDK_EVENT_OWNER,
+  SDK_EVENT_STATUS,
+  SDK_EVENT_RESOURCE
 } from './constants';
 export {
   getHydraFiles,

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -2,7 +2,21 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {SparkPlugin, Page} from '@ciscospark/spark-core';
+import { SparkPlugin, Page } from '@ciscospark/spark-core';
+import {
+  WEBEX_API_EVENTS,
+  API_ACTIVITY_TYPE,
+  API_ACTIVITY_VERB,
+  constructHydraId,
+  hydraTypes
+} from '@ciscospark/common';
+
+const debug = require('debug')('memberships');
+
+const MEMBERSHIP_CREATED = 'created';
+const MEMBERSHIP_DELETED = 'deleted';
+const MEMBERSHIP_UPDATED = 'updated';
+const CONVERSATION_ACTIVITY = 'event:conversation.activity';
 
 /**
  * @typedef {Object} MembershipObject
@@ -24,6 +38,148 @@ import {SparkPlugin, Page} from '@ciscospark/spark-core';
  * @name Memberships
  */
 const Memberships = SparkPlugin.extend({
+  /**
+   * Connect to the web socket to listen to incoming messages.
+   * @returns {Promise}
+   */
+  listen() {
+    // Create a common envelope that we will wrap all events in
+    this.eventEnvelope = {
+      resource: 'memberships',
+      // orgId -- TODO get from this.spark.internal.user
+      // createdBy -- TODO get from this.spark.internal.user
+      ownedBy: 'creator',
+      status: 'active',
+      created: new Date().toISOString(),
+      data: {}
+    };
+    // Register to listen to events
+    return this.spark.internal.mercury.connect()
+      .then(() => this.listenTo(this.spark.internal.mercury, CONVERSATION_ACTIVITY,
+        (event) => this.onWebexApiEvent(event)));
+  },
+
+  /**
+   * Trigger a membership related events.
+   * @param {Object} event
+   * @returns {undefined}
+   */
+  onWebexApiEvent(event) {
+    const {activity} = event.data;
+    console.log(activity);
+
+    // Reply activities are not currently supported
+    if (activity.type === API_ACTIVITY_TYPE.REPLY) {
+      return;
+    }
+
+    /* eslint-disable no-case-declarations */
+    // eslint-disable-next-line padding-line-between-statements
+    switch (activity.verb) {
+      case API_ACTIVITY_VERB.ADD:
+        const membershipCreatedEventData = this.getCreatedEvent(activity);
+        debug(`membership "created" payload: ${JSON.stringify(membershipCreatedEventData)}`);
+        this.trigger(MEMBERSHIP_CREATED, membershipCreatedEventData);
+        break;
+
+      case API_ACTIVITY_VERB.LEAVE:
+        const membershipDeletedEventData = this.getDeletedEvent(activity);
+        debug(`membership "deleted" payload: ${JSON.stringify(membershipDeletedEventData)}`);
+        this.trigger(MEMBERSHIP_DELETED, membershipDeletedEventData);
+        break;
+
+      case API_ACTIVITY_VERB.ACKNOWLEDGE:
+      case API_ACTIVITY_VERB.ADD_MODERATOR:
+      case API_ACTIVITY_VERB.REMOVE_MODERATOR:
+        const membershipUpdatedEventData = this.getUpdatedEvent(activity);
+        debug(`membership "updated" payload: ${JSON.stringify(membershipUpdatedEventData)}`);
+        this.trigger(MEMBERSHIP_UPDATED, membershipUpdatedEventData);
+        break;
+
+      default:
+        break;
+    }
+  },
+
+  /**
+   * Constructs event data object for the "membership created" event,
+   * adhering to Hydra's Webehook data for an "created" event on the "membership" resource.
+   * @param {Object} activity from mercury
+   * @returns {Object} constructed event
+   */
+  getCreatedEvent(activity) {
+    const sdkEvent = this.getCommonSdkEvent(activity);
+    sdkEvent.event = MEMBERSHIP_CREATED;
+    return sdkEvent;
+  },
+
+  /**
+   * Constructs event data object for the "membership deleted" event,
+   * adhering to Hydra's Webehook data for an "deleted" event on the "membership" resource.
+   * @param {Object} activity from mercury
+   * @returns {Object} constructed event
+   */
+  getDeletedEvent(activity) {
+    const sdkEvent = this.getCommonSdkEvent(activity);
+    sdkEvent.event = MEMBERSHIP_DELETED;
+    return sdkEvent;
+  },
+
+  /**
+   * Constructs event data object for the "membership updated" event,
+   * adhering to Hydra's Webehook data for an "updated" event on the "membership" resource.
+   * we add a field "lastSeenId" not yet available in the webhooks if this is an acknowledge actvtity
+   * @param {Object} activity from mercury
+   * @returns {Object} constructed event
+   */
+  getUpdatedEvent(activity) {
+    const sdkEvent = this.getCommonSdkEvent(activity);
+    sdkEvent.event = MEMBERSHIP_UPDATED;
+    if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
+      sdkEvent.data.lastSeenId = constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+    }
+    sdkEvent.data.created = activity.published;
+    return sdkEvent;
+  },
+
+  /**
+   * Constructs common event data object for all membership events
+   * @param {Object} activity from mercury
+   * @returns {Object} constructed event
+   */
+  getCommonSdkEvent(activity) {
+    const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
+    sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+    sdkEvent.data.roomId = constructHydraId(hydraTypes.ROOM, activity.target.id);
+    sdkEvent.data.roomType = activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+    if (activity.verb !== API_ACTIVITY_VERB.ACKNOWLEDGE) {
+      // For most memberships events the person is the one whose membership it is
+      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+        activity.object.entryUUID + ':' + activity.target.id);
+      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.object.entryUUID);
+      sdkEvent.data.personEmail = activity.object.emailAddress || activity.object.entryEmail;
+      sdkEvent.data.personDisplayName = activity.object.displayName;
+      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
+    } else {
+      // For a read receipt the person is the "actor" or the one who did the reading
+      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+        activity.actor.entryUUID + ':' + activity.target.id);  
+      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+      sdkEvent.data.personEmail = activity.actor.emailAddress || activity.actor.entryEmail;
+      sdkEvent.data.personDisplayName = activity.actor.displayName;
+      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
+    }
+    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
+      sdkEvent.data.isModerator = true;
+    } else {
+      sdkEvent.data.isModerator = false;
+    }
+    sdkEvent.data.isMonitor = false;
+    // isRoomHidden
+    return sdkEvent;
+  },
+
+
   /**
    * Adds a person to a room. The person can be added by ID (`personId`) or by
    * Email Address (`personEmail`). The person can be optionally added to the room

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -1,22 +1,20 @@
 /*!
- * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
  */
 
-import { SparkPlugin, Page } from '@ciscospark/spark-core';
+import {SparkPlugin, Page} from '@ciscospark/spark-core';
 import {
-  WEBEX_API_EVENTS,
-  API_ACTIVITY_TYPE,
+  WEBEX_EVENT,
   API_ACTIVITY_VERB,
-  constructHydraId,
-  hydraTypes
+  SDK_EVENT_RESOURCE,
+  SDK_EVENT,
+  SDK_EVENT_OWNER,
+  SDK_EVENT_STATUS,
+  hydraTypes,
+  constructHydraId
 } from '@ciscospark/common';
 
 const debug = require('debug')('memberships');
-
-const MEMBERSHIP_CREATED = 'created';
-const MEMBERSHIP_DELETED = 'deleted';
-const MEMBERSHIP_UPDATED = 'updated';
-const CONVERSATION_ACTIVITY = 'event:conversation.activity';
 
 /**
  * @typedef {Object} MembershipObject
@@ -45,17 +43,19 @@ const Memberships = SparkPlugin.extend({
   listen() {
     // Create a common envelope that we will wrap all events in
     this.eventEnvelope = {
-      resource: 'memberships',
+      resource: SDK_EVENT_RESOURCE.MEMBERSHIPS,
       // orgId -- TODO get from this.spark.internal.user
       // createdBy -- TODO get from this.spark.internal.user
-      ownedBy: 'creator',
-      status: 'active',
+      ownedBy: SDK_EVENT_OWNER.CREATOR,
+      status: SDK_EVENT_STATUS.ACTIVE,
       created: new Date().toISOString(),
       data: {}
     };
+
     // Register to listen to events
     return this.spark.internal.mercury.connect()
-      .then(() => this.listenTo(this.spark.internal.mercury, CONVERSATION_ACTIVITY,
+      .then(() => this.listenTo(this.spark.internal.mercury,
+        WEBEX_EVENT.TEAMS_ACTIVITY,
         (event) => this.onWebexApiEvent(event)));
   },
 
@@ -67,39 +67,84 @@ const Memberships = SparkPlugin.extend({
   onWebexApiEvent(event) {
     const {activity} = event.data;
     console.log(activity);
-
-    // Reply activities are not currently supported
-    if (activity.type === API_ACTIVITY_TYPE.REPLY) {
-      return;
-    }
-
     /* eslint-disable no-case-declarations */
     // eslint-disable-next-line padding-line-between-statements
     switch (activity.verb) {
       case API_ACTIVITY_VERB.ADD:
-        const membershipCreatedEventData = this.getCreatedEvent(activity);
+        const membershipCreatedEventData = 
+          this.getMembershipEventEvent(activity, SDK_EVENT.CREATED);
+
         debug(`membership "created" payload: ${JSON.stringify(membershipCreatedEventData)}`);
-        this.trigger(MEMBERSHIP_CREATED, membershipCreatedEventData);
+        this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
         break;
 
       case API_ACTIVITY_VERB.LEAVE:
-        const membershipDeletedEventData = this.getDeletedEvent(activity);
+        const membershipDeletedEventData =
+          this.getMembershipEventEvent(activity, SDK_EVENT.DELETED);
+
+
         debug(`membership "deleted" payload: ${JSON.stringify(membershipDeletedEventData)}`);
-        this.trigger(MEMBERSHIP_DELETED, membershipDeletedEventData);
+        this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
         break;
 
       case API_ACTIVITY_VERB.ACKNOWLEDGE:
       case API_ACTIVITY_VERB.ADD_MODERATOR:
       case API_ACTIVITY_VERB.REMOVE_MODERATOR:
-        const membershipUpdatedEventData = this.getUpdatedEvent(activity);
+        const membershipUpdatedEventData =
+          this.getMembershipEventEvent(activity, SDK_EVENT.UPDATED);
+
         debug(`membership "updated" payload: ${JSON.stringify(membershipUpdatedEventData)}`);
-        this.trigger(MEMBERSHIP_UPDATED, membershipUpdatedEventData);
+        this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
         break;
 
       default:
         break;
     }
   },
+
+  /**
+   * Constructs the data object for an event on the memberships resource,
+   * adhering to Hydra's Webehook data structure memberships.
+   * @param {Object} activity from mercury
+   * @param {Object} event type of "webhook" event
+   * @returns {Object} constructed event
+   */
+  getMembershipEventEvent(activity, event) {
+    const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
+
+    sdkEvent.event = event;
+    sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+    sdkEvent.data.roomId = constructHydraId(hydraTypes.ROOM, activity.target.id);
+    sdkEvent.data.roomType = activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+    if (activity.verb !== API_ACTIVITY_VERB.ACKNOWLEDGE) {
+      // For most memberships events the person is the one whose membership it is
+      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+        `${activity.object.entryUUID}:${activity.target.id}`);
+      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.object.entryUUID);
+      sdkEvent.data.personEmail = activity.object.emailAddress || activity.object.entryEmail;
+      sdkEvent.data.personDisplayName = activity.object.displayName;
+      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
+    }
+    else {
+      // For a read receipt the person is the "actor" or the one who did the reading
+      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+        `${activity.actor.entryUUID}:${activity.target.id}`);
+      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+      sdkEvent.data.personEmail = activity.actor.emailAddress || activity.actor.entryEmail;
+      sdkEvent.data.personDisplayName = activity.actor.displayName;
+      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
+    }
+    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
+      sdkEvent.data.isModerator = true;
+    } else {
+      sdkEvent.data.isModerator = false;
+    }
+    sdkEvent.data.isMonitor = false;
+    // isRoomHidden
+
+    return sdkEvent;
+  },
+
 
   /**
    * Constructs event data object for the "membership created" event,
@@ -109,19 +154,24 @@ const Memberships = SparkPlugin.extend({
    */
   getCreatedEvent(activity) {
     const sdkEvent = this.getCommonSdkEvent(activity);
-    sdkEvent.event = MEMBERSHIP_CREATED;
+
+    sdkEvent.event = SDK_EVENT.CREATED;
+
     return sdkEvent;
   },
 
   /**
-   * Constructs event data object for the "membership deleted" event,
-   * adhering to Hydra's Webehook data for an "deleted" event on the "membership" resource.
+   * Constructs the data object for an event on the memberships resource,
+   * adhering to Hydra's Webehook data structure memberships.
    * @param {Object} activity from mercury
+   * @param {Object} event type of "webhook" event
    * @returns {Object} constructed event
    */
   getDeletedEvent(activity) {
     const sdkEvent = this.getCommonSdkEvent(activity);
-    sdkEvent.event = MEMBERSHIP_DELETED;
+
+    sdkEvent.event = SDK_EVENT.DELETED;
+
     return sdkEvent;
   },
 
@@ -134,7 +184,7 @@ const Memberships = SparkPlugin.extend({
    */
   getUpdatedEvent(activity) {
     const sdkEvent = this.getCommonSdkEvent(activity);
-    sdkEvent.event = MEMBERSHIP_UPDATED;
+    sdkEvent.event = SDK_EVENT.UPDATED;
     if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
       sdkEvent.data.lastSeenId = constructHydraId(hydraTypes.MESSAGE, activity.object.id);
     }

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -17,6 +17,7 @@ import {
 } from '@ciscospark/common';
 
 const debug = require('debug')('memberships');
+const _ = require('lodash');
 
 /**
  * @typedef {Object} MembershipObject
@@ -77,7 +78,7 @@ const Memberships = SparkPlugin.extend({
   /**
    * Trigger a membership related events.
    * @param {Object} event
-   * @returns {undefined}
+   * @returns {undefined} -- nothing //linter requires return in JSDoc
    */
   onWebexApiEvent(event) {
     const {activity} = event.data;
@@ -88,18 +89,22 @@ const Memberships = SparkPlugin.extend({
         const membershipCreatedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.CREATED);
 
-        debug(`membership "created" payload: \
-          ${JSON.stringify(membershipCreatedEventData)}`);
-        this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
+        if (membershipCreatedEventData) {
+          debug(`membership "created" payload: \
+            ${JSON.stringify(membershipCreatedEventData)}`);
+          this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
+        }
         break;
 
       case API_ACTIVITY_VERB.LEAVE:
         const membershipDeletedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.DELETED);
 
-        debug(`membership "deleted" payload: \
-          ${JSON.stringify(membershipDeletedEventData)}`);
-        this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
+        if (membershipDeletedEventData) {
+          debug(`membership "deleted" payload: \
+            ${JSON.stringify(membershipDeletedEventData)}`);
+          this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
+        }
         break;
 
       case API_ACTIVITY_VERB.ADD_MODERATOR:
@@ -108,18 +113,22 @@ const Memberships = SparkPlugin.extend({
         const membershipUpdatedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.UPDATED);
 
-        debug(`membership "updated" payload: \
-          ${JSON.stringify(membershipUpdatedEventData)}`);
-        this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
+        if (membershipUpdatedEventData) {
+          debug(`membership "updated" payload: \
+            ${JSON.stringify(membershipUpdatedEventData)}`);
+          this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
+        }
         break;
 
       case API_ACTIVITY_VERB.ACKNOWLEDGE:
         const membershipSeenEventData =
           this.getMembershipEvent(activity, SDK_EVENT.SEEN);
 
-        debug(`membership "updated" payload: \
-          ${JSON.stringify(membershipSeenEventData)}`);
-        this.trigger(SDK_EVENT.SEEN, membershipSeenEventData);
+        if (membershipSeenEventData) {
+          debug(`membership "updated" payload: \
+            ${JSON.stringify(membershipSeenEventData)}`);
+          this.trigger(SDK_EVENT.SEEN, membershipSeenEventData);
+        }
         break;
 
       default:
@@ -135,11 +144,7 @@ const Memberships = SparkPlugin.extend({
    * @returns {Object} constructed event
    */
   getMembershipEvent(activity, event) {
-    // As per the comment from Andrew Holstead, attempted alternate
-    // ways to copy the envelope data, but these impacted the original:
-    // const sdkEvent = _.clone(this.eventEnvelope, true);
-    // const sdkEvent = Object.assign({}, this.eventEnvelope);
-    const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
+    const sdkEvent = _.cloneDeep(this.eventEnvelope);
     let member = '';
     let space = '';
 
@@ -167,7 +172,6 @@ const Memberships = SparkPlugin.extend({
       sdkEvent.data.isModerator = false;
     }
     sdkEvent.data.isMonitor = false;
-    // isRoomHidden
 
     if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
       // For a read receipt the person is the "actor" or the one who did the reading
@@ -186,6 +190,11 @@ const Memberships = SparkPlugin.extend({
       // For most memberships events the person is the 'object" or the one whose membership it is
       member = API_ACTIVITY_FIELD.OBJECT;
       space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
+    }
+    if ((!activity[member]) || (!activity[space])) {
+      console.error('Unable to generate SDK event from mercury socket activity');
+
+      return null;
     }
     sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
       `${activity[member].entryUUID}:${activity[space].id}`);

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -44,13 +44,26 @@ const Memberships = SparkPlugin.extend({
     // Create a common envelope that we will wrap all events in
     this.eventEnvelope = {
       resource: SDK_EVENT_RESOURCE.MEMBERSHIPS,
-      // orgId -- TODO get from this.spark.internal.user
-      // createdBy -- TODO get from this.spark.internal.user
+      // id -- webhook id concept does not correlate to SDK socket event
+      // name -- webhook name concept does not correlate to SDK socket event
+      // targetUrl -- targetUrl concept does not correlate to SDK socket event
+      // secret -- secret concept does not correlate to SDK socket event
       ownedBy: SDK_EVENT_OWNER.CREATOR,
       status: SDK_EVENT_STATUS.ACTIVE,
       created: new Date().toISOString(),
       data: {}
     };
+    const that = this;
+
+
+    that.spark.people.get('me')
+      .then((person) => {
+        that.eventEnvelope.createdBy = person.id;
+        that.eventEnvelope.orgId = person.orgId;
+      }).catch((e) => {
+        console.error(`Unable to get person info for memberships 
+          event envelope ${e.message}`);
+      });
 
     // Register to listen to events
     return this.spark.internal.mercury.connect()
@@ -66,13 +79,12 @@ const Memberships = SparkPlugin.extend({
    */
   onWebexApiEvent(event) {
     const {activity} = event.data;
-    console.log(activity);
+
     /* eslint-disable no-case-declarations */
-    // eslint-disable-next-line padding-line-between-statements
     switch (activity.verb) {
       case API_ACTIVITY_VERB.ADD:
-        const membershipCreatedEventData = 
-          this.getMembershipEventEvent(activity, SDK_EVENT.CREATED);
+        const membershipCreatedEventData =
+          this.getMembershipEvent(activity, SDK_EVENT.CREATED);
 
         debug(`membership "created" payload: ${JSON.stringify(membershipCreatedEventData)}`);
         this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
@@ -80,21 +92,27 @@ const Memberships = SparkPlugin.extend({
 
       case API_ACTIVITY_VERB.LEAVE:
         const membershipDeletedEventData =
-          this.getMembershipEventEvent(activity, SDK_EVENT.DELETED);
-
+          this.getMembershipEvent(activity, SDK_EVENT.DELETED);
 
         debug(`membership "deleted" payload: ${JSON.stringify(membershipDeletedEventData)}`);
         this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
         break;
 
-      case API_ACTIVITY_VERB.ACKNOWLEDGE:
       case API_ACTIVITY_VERB.ADD_MODERATOR:
       case API_ACTIVITY_VERB.REMOVE_MODERATOR:
         const membershipUpdatedEventData =
-          this.getMembershipEventEvent(activity, SDK_EVENT.UPDATED);
+          this.getMembershipEvent(activity, SDK_EVENT.UPDATED);
 
         debug(`membership "updated" payload: ${JSON.stringify(membershipUpdatedEventData)}`);
         this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
+        break;
+
+      case API_ACTIVITY_VERB.ACKNOWLEDGE:
+        const membershipSeenEventData =
+          this.getMembershipEvent(activity, SDK_EVENT.SEEN);
+
+        debug(`membership "updated" payload: ${JSON.stringify(membershipSeenEventData)}`);
+        this.trigger(SDK_EVENT.SEEN, membershipSeenEventData);
         break;
 
       default:
@@ -109,123 +127,43 @@ const Memberships = SparkPlugin.extend({
    * @param {Object} event type of "webhook" event
    * @returns {Object} constructed event
    */
-  getMembershipEventEvent(activity, event) {
+  getMembershipEvent(activity, event) {
     const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
+    let member = '';
 
     sdkEvent.event = event;
+    sdkEvent.data.created = activity.published;
     sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-    sdkEvent.data.roomId = constructHydraId(hydraTypes.ROOM, activity.target.id);
-    sdkEvent.data.roomType = activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+    sdkEvent.data.roomId =
+      constructHydraId(hydraTypes.ROOM, activity.target.id);
+    sdkEvent.data.roomType =
+      activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
+      sdkEvent.data.isModerator = true;
+    }
+    else {
+      sdkEvent.data.isModerator = false;
+    }
+    sdkEvent.data.isMonitor = false;
+    // isRoomHidden
+
     if (activity.verb !== API_ACTIVITY_VERB.ACKNOWLEDGE) {
-      // For most memberships events the person is the one whose membership it is
-      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-        `${activity.object.entryUUID}:${activity.target.id}`);
-      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.object.entryUUID);
-      sdkEvent.data.personEmail = activity.object.emailAddress || activity.object.entryEmail;
-      sdkEvent.data.personDisplayName = activity.object.displayName;
-      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
+      // For most memberships events the person is the 'object" or the one whose membership it is
+      member = 'object';
     }
     else {
       // For a read receipt the person is the "actor" or the one who did the reading
-      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-        `${activity.actor.entryUUID}:${activity.target.id}`);
-      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
-      sdkEvent.data.personEmail = activity.actor.emailAddress || activity.actor.entryEmail;
-      sdkEvent.data.personDisplayName = activity.actor.displayName;
-      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
-    }
-    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
-      sdkEvent.data.isModerator = true;
-    } else {
-      sdkEvent.data.isModerator = false;
-    }
-    sdkEvent.data.isMonitor = false;
-    // isRoomHidden
-
-    return sdkEvent;
-  },
-
-
-  /**
-   * Constructs event data object for the "membership created" event,
-   * adhering to Hydra's Webehook data for an "created" event on the "membership" resource.
-   * @param {Object} activity from mercury
-   * @returns {Object} constructed event
-   */
-  getCreatedEvent(activity) {
-    const sdkEvent = this.getCommonSdkEvent(activity);
-
-    sdkEvent.event = SDK_EVENT.CREATED;
-
-    return sdkEvent;
-  },
-
-  /**
-   * Constructs the data object for an event on the memberships resource,
-   * adhering to Hydra's Webehook data structure memberships.
-   * @param {Object} activity from mercury
-   * @param {Object} event type of "webhook" event
-   * @returns {Object} constructed event
-   */
-  getDeletedEvent(activity) {
-    const sdkEvent = this.getCommonSdkEvent(activity);
-
-    sdkEvent.event = SDK_EVENT.DELETED;
-
-    return sdkEvent;
-  },
-
-  /**
-   * Constructs event data object for the "membership updated" event,
-   * adhering to Hydra's Webehook data for an "updated" event on the "membership" resource.
-   * we add a field "lastSeenId" not yet available in the webhooks if this is an acknowledge actvtity
-   * @param {Object} activity from mercury
-   * @returns {Object} constructed event
-   */
-  getUpdatedEvent(activity) {
-    const sdkEvent = this.getCommonSdkEvent(activity);
-    sdkEvent.event = SDK_EVENT.UPDATED;
-    if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
+      member = 'actor';
+      // And the "object" is the message that was last seen
       sdkEvent.data.lastSeenId = constructHydraId(hydraTypes.MESSAGE, activity.object.id);
     }
-    sdkEvent.data.created = activity.published;
-    return sdkEvent;
-  },
+    sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+      `${activity[member].entryUUID}:${activity.target.id}`);
+    sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
+    sdkEvent.data.personEmail = activity[member].emailAddress || activity[member].entryEmail;
+    sdkEvent.data.personDisplayName = activity[member].displayName;
+    sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity[member].orgId);
 
-  /**
-   * Constructs common event data object for all membership events
-   * @param {Object} activity from mercury
-   * @returns {Object} constructed event
-   */
-  getCommonSdkEvent(activity) {
-    const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
-    sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-    sdkEvent.data.roomId = constructHydraId(hydraTypes.ROOM, activity.target.id);
-    sdkEvent.data.roomType = activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
-    if (activity.verb !== API_ACTIVITY_VERB.ACKNOWLEDGE) {
-      // For most memberships events the person is the one whose membership it is
-      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-        activity.object.entryUUID + ':' + activity.target.id);
-      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.object.entryUUID);
-      sdkEvent.data.personEmail = activity.object.emailAddress || activity.object.entryEmail;
-      sdkEvent.data.personDisplayName = activity.object.displayName;
-      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
-    } else {
-      // For a read receipt the person is the "actor" or the one who did the reading
-      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-        activity.actor.entryUUID + ':' + activity.target.id);  
-      sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
-      sdkEvent.data.personEmail = activity.actor.emailAddress || activity.actor.entryEmail;
-      sdkEvent.data.personDisplayName = activity.actor.displayName;
-      sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity.actor.orgId);
-    }
-    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
-      sdkEvent.data.isModerator = true;
-    } else {
-      sdkEvent.data.isModerator = false;
-    }
-    sdkEvent.data.isMonitor = false;
-    // isRoomHidden
     return sdkEvent;
   },
 

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -61,7 +61,7 @@ const Memberships = SparkPlugin.extend({
         that.eventEnvelope.createdBy = person.id;
         that.eventEnvelope.orgId = person.orgId;
       }).catch((e) => {
-        console.error(`Unable to get person info for memberships 
+        console.error(`Unable to get person info for memberships \
           event envelope ${e.message}`);
       });
 
@@ -86,7 +86,8 @@ const Memberships = SparkPlugin.extend({
         const membershipCreatedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.CREATED);
 
-        debug(`membership "created" payload: ${JSON.stringify(membershipCreatedEventData)}`);
+        debug(`membership "created" payload: \
+          ${JSON.stringify(membershipCreatedEventData)}`);
         this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
         break;
 
@@ -94,7 +95,8 @@ const Memberships = SparkPlugin.extend({
         const membershipDeletedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.DELETED);
 
-        debug(`membership "deleted" payload: ${JSON.stringify(membershipDeletedEventData)}`);
+        debug(`membership "deleted" payload: \
+          ${JSON.stringify(membershipDeletedEventData)}`);
         this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
         break;
 
@@ -103,7 +105,8 @@ const Memberships = SparkPlugin.extend({
         const membershipUpdatedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.UPDATED);
 
-        debug(`membership "updated" payload: ${JSON.stringify(membershipUpdatedEventData)}`);
+        debug(`membership "updated" payload: \
+          ${JSON.stringify(membershipUpdatedEventData)}`);
         this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
         break;
 
@@ -111,7 +114,8 @@ const Memberships = SparkPlugin.extend({
         const membershipSeenEventData =
           this.getMembershipEvent(activity, SDK_EVENT.SEEN);
 
-        debug(`membership "updated" payload: ${JSON.stringify(membershipSeenEventData)}`);
+        debug(`membership "updated" payload: \
+          ${JSON.stringify(membershipSeenEventData)}`);
         this.trigger(SDK_EVENT.SEEN, membershipSeenEventData);
         break;
 
@@ -155,14 +159,18 @@ const Memberships = SparkPlugin.extend({
       // For a read receipt the person is the "actor" or the one who did the reading
       member = 'actor';
       // And the "object" is the message that was last seen
-      sdkEvent.data.lastSeenId = constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+      sdkEvent.data.lastSeenId =
+        constructHydraId(hydraTypes.MESSAGE, activity.object.id);
     }
     sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
       `${activity[member].entryUUID}:${activity.target.id}`);
-    sdkEvent.data.personId = constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
-    sdkEvent.data.personEmail = activity[member].emailAddress || activity[member].entryEmail;
+    sdkEvent.data.personId =
+      constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
+    sdkEvent.data.personEmail =
+      activity[member].emailAddress || activity[member].entryEmail;
     sdkEvent.data.personDisplayName = activity[member].displayName;
-    sdkEvent.data.personOrgId = constructHydraId(hydraTypes.ORGANIZATION, activity[member].orgId);
+    sdkEvent.data.personOrgId =
+      constructHydraId(hydraTypes.ORGANIZATION, activity[member].orgId);
 
     return sdkEvent;
   },

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -5,6 +5,8 @@
 import {SparkPlugin, Page} from '@ciscospark/spark-core';
 import {
   WEBEX_EVENT,
+  WEBEX_SPACE_TYPE,
+  API_ACTIVITY_FIELD,
   API_ACTIVITY_VERB,
   SDK_EVENT_RESOURCE,
   SDK_EVENT,
@@ -102,6 +104,7 @@ const Memberships = SparkPlugin.extend({
 
       case API_ACTIVITY_VERB.ADD_MODERATOR:
       case API_ACTIVITY_VERB.REMOVE_MODERATOR:
+      case API_ACTIVITY_VERB.HIDE:
         const membershipUpdatedEventData =
           this.getMembershipEvent(activity, SDK_EVENT.UPDATED);
 
@@ -132,16 +135,31 @@ const Memberships = SparkPlugin.extend({
    * @returns {Object} constructed event
    */
   getMembershipEvent(activity, event) {
+    // As per the comment from Andrew Holstead, attempted alternate
+    // ways to copy the envelope data, but these impacted the original:
+    // const sdkEvent = _.clone(this.eventEnvelope, true);
+    // const sdkEvent = Object.assign({}, this.eventEnvelope);
     const sdkEvent = JSON.parse(JSON.stringify(this.eventEnvelope));
     let member = '';
+    let space = '';
 
     sdkEvent.event = event;
     sdkEvent.data.created = activity.published;
     sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-    sdkEvent.data.roomId =
+    if (activity.verb !== API_ACTIVITY_VERB.HIDE) {
+      sdkEvent.data.roomId =
       constructHydraId(hydraTypes.ROOM, activity.target.id);
-    sdkEvent.data.roomType =
-      activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+      sdkEvent.data.roomType =
+        activity.target.tags.includes('ONE_ON_ONE') ?
+          WEBEX_SPACE_TYPE.DIRECT : WEBEX_SPACE_TYPE.GROUP;
+      sdkEvent.data.isRoomHidden = false; // any activity unhides a space.
+    }
+    else {
+      sdkEvent.data.roomId =
+      constructHydraId(hydraTypes.ROOM, activity.object.id);
+      sdkEvent.data.roomType = WEBEX_SPACE_TYPE.DIRECT; // currently hidden attribute is only set on 1-1
+      sdkEvent.data.isRoomHidden = true;
+    }
     if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
       sdkEvent.data.isModerator = true;
     }
@@ -151,19 +169,26 @@ const Memberships = SparkPlugin.extend({
     sdkEvent.data.isMonitor = false;
     // isRoomHidden
 
-    if (activity.verb !== API_ACTIVITY_VERB.ACKNOWLEDGE) {
-      // For most memberships events the person is the 'object" or the one whose membership it is
-      member = 'object';
-    }
-    else {
+    if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
       // For a read receipt the person is the "actor" or the one who did the reading
-      member = 'actor';
+      member = API_ACTIVITY_FIELD.ACTOR;
+      space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
       // And the "object" is the message that was last seen
       sdkEvent.data.lastSeenId =
         constructHydraId(hydraTypes.MESSAGE, activity.object.id);
     }
+    else if (activity.verb === API_ACTIVITY_VERB.HIDE) {
+      // For a hide activity the person is also the "actor"
+      member = API_ACTIVITY_FIELD.ACTOR;
+      space = API_ACTIVITY_FIELD.OBJECT; // but the space is now the "object"
+    }
+    else {
+      // For most memberships events the person is the 'object" or the one whose membership it is
+      member = API_ACTIVITY_FIELD.OBJECT;
+      space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
+    }
     sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-      `${activity[member].entryUUID}:${activity.target.id}`);
+      `${activity[member].entryUUID}:${activity[space].id}`);
     sdkEvent.data.personId =
       constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
     sdkEvent.data.personEmail =

--- a/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@ciscospark/plugin-memberships/src/memberships.js
@@ -3,6 +3,7 @@
  */
 
 import {SparkPlugin, Page} from '@ciscospark/spark-core';
+import {cloneDeep} from 'lodash';
 import {
   WEBEX_EVENT,
   WEBEX_SPACE_TYPE,
@@ -17,7 +18,6 @@ import {
 } from '@ciscospark/common';
 
 const debug = require('debug')('memberships');
-const _ = require('lodash');
 
 /**
  * @typedef {Object} MembershipObject
@@ -56,23 +56,23 @@ const Memberships = SparkPlugin.extend({
       created: new Date().toISOString(),
       data: {}
     };
-    const that = this;
 
-
-    that.spark.people.get('me')
+    // We need to query for some of the envelope info...
+    this.spark.people.get('me')
       .then((person) => {
-        that.eventEnvelope.createdBy = person.id;
-        that.eventEnvelope.orgId = person.orgId;
+        this.eventEnvelope.createdBy = person.id;
+        this.eventEnvelope.orgId = person.orgId;
       }).catch((e) => {
         console.error(`Unable to get person info for memberships \
           event envelope ${e.message}`);
       });
 
     // Register to listen to events
-    return this.spark.internal.mercury.connect()
-      .then(() => this.listenTo(this.spark.internal.mercury,
+    return this.spark.internal.mercury.connect().then(() => {
+      this.listenTo(this.spark.internal.mercury,
         WEBEX_EVENT.TEAMS_ACTIVITY,
-        (event) => this.onWebexApiEvent(event)));
+        (event) => this.onWebexApiEvent(event));
+    });
   },
 
   /**
@@ -144,9 +144,9 @@ const Memberships = SparkPlugin.extend({
    * @returns {Object} constructed event
    */
   getMembershipEvent(activity, event) {
-    const sdkEvent = _.cloneDeep(this.eventEnvelope);
-    let member = '';
-    let space = '';
+    const sdkEvent = cloneDeep(this.eventEnvelope);
+    let member;
+    let space;
 
     sdkEvent.event = event;
     sdkEvent.data.created = activity.published;
@@ -192,7 +192,8 @@ const Memberships = SparkPlugin.extend({
       space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
     }
     if ((!activity[member]) || (!activity[space])) {
-      console.error('Unable to generate SDK event from mercury socket activity');
+      console.error('Unable to generate SDK event ' +
+        'from mercury socket activity');
 
       return null;
     }

--- a/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
@@ -110,6 +110,7 @@ const Messages = SparkPlugin.extend({
       roomId: constructHydraId(hydraTypes.ROOM, activity.target.id),
       roomType,
       text: activity.object.displayName,
+      files: getHydraFiles(activity),
       personId: constructHydraId(hydraTypes.PEOPLE, activity.actor.id),
       personEmail: activity.actor.emailAddress || activity.actor.entryEmail,
       created: activity.published

--- a/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
@@ -74,11 +74,6 @@ const Messages = SparkPlugin.extend({
   onConversationActivityEvent(event) {
     const {activity} = event.data;
 
-    // Reply activities are not supported.
-    if (activity.activityType === API_ACTIVITY_TYPE.REPLY) {
-      return;
-    }
-
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
       case API_ACTIVITY_VERB.SHARE:

--- a/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
@@ -3,7 +3,6 @@
  */
 
 import {
-  API_ACTIVITY_TYPE,
   API_ACTIVITY_VERB,
   constructHydraId,
   deconstructHydraId,

--- a/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
@@ -104,7 +104,6 @@ const Messages = SparkPlugin.extend({
       roomId: constructHydraId(hydraTypes.ROOM, activity.target.id),
       roomType,
       text: activity.object.displayName,
-      files: getHydraFiles(activity),
       personId: constructHydraId(hydraTypes.PEOPLE, activity.actor.id),
       personEmail: activity.actor.emailAddress || activity.actor.entryEmail,
       created: activity.published

--- a/packages/node_modules/samples/browser-socket/app.js
+++ b/packages/node_modules/samples/browser-socket/app.js
@@ -69,11 +69,33 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
       webex.messages.listen()
         .then(() => {
           console.log('connected');
-          console.log('listening to messages');
+          console.log('listening to message events');
           updateStatus(true);
           webex.messages.on('created', (message) => {
-            console.log('created');
+            console.log('message created event:');
             console.log(message);
+          });
+        })
+        .catch((err) => {
+          console.error(`error listening to messages: ${err}`);
+          updateStatus(false);
+        });
+      webex.memberships.listen()
+        .then(() => {
+          console.log('connected');
+          console.log('listening to membership events');
+          updateStatus(true);
+          webex.memberships.on('created', (membership) => {
+            console.log('membership created event');
+            console.log(membership);
+          });
+          webex.memberships.on('deleted', (membership) => {
+            console.log('membership deleted event');
+            console.log(membership);
+          });
+          webex.memberships.on('updated', (membership) => {
+            console.log('membership updated event');
+            console.log(membership);
           });
         })
         .catch((err) => {

--- a/packages/node_modules/samples/browser-socket/app.js
+++ b/packages/node_modules/samples/browser-socket/app.js
@@ -66,9 +66,9 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
 
   authorize()
     .then(() => {
+      console.log('connected');
       webex.messages.listen()
         .then(() => {
-          console.log('connected');
           console.log('listening to message events');
           updateStatus(true);
           webex.messages.on('created', (message) => {
@@ -82,7 +82,6 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
         });
       webex.memberships.listen()
         .then(() => {
-          console.log('connected');
           console.log('listening to membership events');
           updateStatus(true);
           webex.memberships.on('created', (membership) => {
@@ -95,6 +94,10 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
           });
           webex.memberships.on('updated', (membership) => {
             console.log('membership updated event');
+            console.log(membership);
+          });
+          webex.memberships.on('seen', (membership) => {
+            console.log('membership seen (read receipt) event');
             console.log(membership);
           });
         })


### PR DESCRIPTION
# Pull Request Template

## Description

Add membership events -- new PR with cherry picked commits thanks to help from @adamweeks   Should address all comments from https://github.com/webex/spark-js-sdk/pull/1135

New events:
- membership:created
- membership:deleted
- membership:updated  -- change in moderator status or isRoomHidden status
- membership:seen -- read receipt

Event DTO is as similar as possible to the membership webhooks

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

No tests yet. Since the goal here is to have these events match the webhooks, an ideal test would be to create a space, add some members, modify some (ie: make moderators), send and receive some read receites etc. The framework should register for both the SDK events and the webhooks and then it can compare them. Need to learn more about how to create users to support a test like this.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
