### PR TITLE
fix: change web-ha-messaging to web-high-availability-messaging

### DIFF
--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -834,7 +834,7 @@ const Conversation = SparkPlugin.extend({
    */
   _inferConversationUrl(conversation) {
     if (conversation.id) {
-      return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
+      return this.spark.internal.feature.getFeature('developer', 'web-high-availability')
         .then((haMessagingEnabled) => {
           if (haMessagingEnabled) {
             // recompute conversation URL each time as the host may have changed

--- a/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-conversation/src/conversation.js
@@ -834,7 +834,7 @@ const Conversation = SparkPlugin.extend({
    */
   _inferConversationUrl(conversation) {
     if (conversation.id) {
-      return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+      return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
         .then((haMessagingEnabled) => {
           if (haMessagingEnabled) {
             // recompute conversation URL each time as the host may have changed

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -119,7 +119,7 @@ const Mercury = SparkPlugin.extend({
       webSocketUrl = this.spark.internal.device.webSocketUrl;
     }
 
-    return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+    return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
       .then((haMessagingEnabled) => {
         if (haMessagingEnabled) {
           return this.spark.internal.device.useServiceCatalogUrl(webSocketUrl);
@@ -189,7 +189,7 @@ const Mercury = SparkPlugin.extend({
         });
         callback();
 
-        return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+        return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
           .then((haMessagingEnabled) => {
             if (haMessagingEnabled) {
               return this.spark.internal.device.fetchNewUrls(attemptWSUrl);
@@ -237,7 +237,7 @@ const Mercury = SparkPlugin.extend({
           return callback(reason);
         }
         if (reason instanceof ConnectionError) {
-          return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+          return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
             .then((haMessagingEnabled) => {
               if (haMessagingEnabled) {
                 this.logger.info('mercury: received a generic connection error, will try to connect to another datacenter');

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/src/mercury.js
@@ -119,7 +119,7 @@ const Mercury = SparkPlugin.extend({
       webSocketUrl = this.spark.internal.device.webSocketUrl;
     }
 
-    return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
+    return this.spark.internal.feature.getFeature('developer', 'web-high-availability')
       .then((haMessagingEnabled) => {
         if (haMessagingEnabled) {
           return this.spark.internal.device.useServiceCatalogUrl(webSocketUrl);
@@ -189,7 +189,7 @@ const Mercury = SparkPlugin.extend({
         });
         callback();
 
-        return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
+        return this.spark.internal.feature.getFeature('developer', 'web-high-availability')
           .then((haMessagingEnabled) => {
             if (haMessagingEnabled) {
               return this.spark.internal.device.fetchNewUrls(attemptWSUrl);
@@ -237,7 +237,7 @@ const Mercury = SparkPlugin.extend({
           return callback(reason);
         }
         if (reason instanceof ConnectionError) {
-          return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
+          return this.spark.internal.feature.getFeature('developer', 'web-high-availability')
             .then((haMessagingEnabled) => {
               if (haMessagingEnabled) {
                 this.logger.info('mercury: received a generic connection error, will try to connect to another datacenter');

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
@@ -68,14 +68,14 @@ describe('plugin-mercury', function () {
         it('connects to mercury', () => spark.internal.mercury.connect());
       });
 
-      describe('when web-high-availability-messaging is enabled', () => {
+      describe('when web-high-availability is enabled', () => {
         it('connects to mercury using service catalog url', () => {
           let defaultWebSocketUrl;
 
           // we need to ensure the feature is set for user before "registering"
           // the device
           return spark.internal.device.register()
-            .then(() => spark.internal.feature.setFeature('developer', 'web-high-availability-messaging', true))
+            .then(() => spark.internal.feature.setFeature('developer', 'web-high-availability', true))
             .then(() => spark.internal.device.unregister())
             // start the test flow the device list
             .then(() => spark.internal.device.register())

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/integration/spec/mercury.js
@@ -68,14 +68,14 @@ describe('plugin-mercury', function () {
         it('connects to mercury', () => spark.internal.mercury.connect());
       });
 
-      describe('when web-ha-messaging is enabled', () => {
+      describe('when web-high-availability-messaging is enabled', () => {
         it('connects to mercury using service catalog url', () => {
           let defaultWebSocketUrl;
 
           // we need to ensure the feature is set for user before "registering"
           // the device
           return spark.internal.device.register()
-            .then(() => spark.internal.feature.setFeature('developer', 'web-ha-messaging', true))
+            .then(() => spark.internal.feature.setFeature('developer', 'web-high-availability-messaging', true))
             .then(() => spark.internal.device.unregister())
             // start the test flow the device list
             .then(() => spark.internal.device.register())

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -332,7 +332,7 @@ describe('plugin-mercury', () => {
         //   });
         // });
 
-        describe('when web-ha-messaging feature is enabled', () => {
+        describe('when web-high-availability-messaging feature is enabled', () => {
           it('marks current socket url as failed and get new one on Connection Error', () => {
             spark.internal.feature.getFeature.returns(Promise.resolve(true));
             socketOpenStub.restore();
@@ -559,7 +559,7 @@ describe('plugin-mercury', () => {
           assert.notMatch(wsUrl, /multipleConnections/);
         }));
 
-      describe('when web-ha-messaging is enabled', () => {
+      describe('when web-high-availability-messaging is enabled', () => {
         it('uses webSocketUrl provided by device', () => {
           spark.internal.device.useServiceCatalogUrl = sinon.stub().returns(Promise.resolve('ws://example-2.com'));
           spark.internal.feature.getFeature.onCall(0).returns(Promise.resolve(true));

--- a/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-mercury/test/unit/spec/mercury.js
@@ -332,7 +332,7 @@ describe('plugin-mercury', () => {
         //   });
         // });
 
-        describe('when web-high-availability-messaging feature is enabled', () => {
+        describe('when web-high-availability feature is enabled', () => {
           it('marks current socket url as failed and get new one on Connection Error', () => {
             spark.internal.feature.getFeature.returns(Promise.resolve(true));
             socketOpenStub.restore();
@@ -559,7 +559,7 @@ describe('plugin-mercury', () => {
           assert.notMatch(wsUrl, /multipleConnections/);
         }));
 
-      describe('when web-high-availability-messaging is enabled', () => {
+      describe('when web-high-availability is enabled', () => {
         it('uses webSocketUrl provided by device', () => {
           spark.internal.device.useServiceCatalogUrl = sinon.stub().returns(Promise.resolve('ws://example-2.com'));
           spark.internal.feature.getFeature.onCall(0).returns(Promise.resolve(true));

--- a/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
@@ -270,7 +270,7 @@ const Team = SparkPlugin.extend({
   /* eslint-disable require-jsdoc */
   _inferTeamUrl(team) {
     if (team.id) {
-      return this.spark.internal.feature.getFeature('developer', 'web-ha-messaging')
+      return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
         .then((haMessagingEnabled) => {
           if (haMessagingEnabled) {
             // recompute team URL each time as the host may have changed since last usage

--- a/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-team/src/team.js
@@ -270,7 +270,7 @@ const Team = SparkPlugin.extend({
   /* eslint-disable require-jsdoc */
   _inferTeamUrl(team) {
     if (team.id) {
-      return this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging')
+      return this.spark.internal.feature.getFeature('developer', 'web-high-availability')
         .then((haMessagingEnabled) => {
           if (haMessagingEnabled) {
             // recompute team URL each time as the host may have changed since last usage

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -143,7 +143,7 @@ const Device = SparkPlugin.extend({
 
   @waitForValue('@')
   determineService(url) {
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       for (const key of Object.keys(this.serviceHostMap.serviceLinks)) {
@@ -170,7 +170,7 @@ const Device = SparkPlugin.extend({
 
   @waitForValue('@')
   getServiceUrl(service) {
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       return this._getServiceUrl(this.serviceHostMap.serviceLinks, service)
@@ -291,7 +291,7 @@ const Device = SparkPlugin.extend({
     if (service === 'idbroker') {
       return Promise.resolve(false);
     }
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       return this._isService(this.serviceHostMap.serviceLinks, service)
@@ -309,7 +309,7 @@ const Device = SparkPlugin.extend({
     if (!uri) {
       return Promise.reject(new Error('`uri` is a required parameter'));
     }
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       if (this._isServiceUrl(this.serviceHostMap.serviceLinks, uri) ||
@@ -339,7 +339,7 @@ const Device = SparkPlugin.extend({
       return Promise.reject(new Error('`service` is a required parameter'));
     }
 
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       const s = this.serviceCatalog.get(service);
@@ -362,7 +362,7 @@ const Device = SparkPlugin.extend({
   },
 
   _isServiceUrl(target, uri) {
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       for (const key of Object.keys(target)) {
@@ -494,7 +494,7 @@ const Device = SparkPlugin.extend({
   },
 
   _updateServiceCatalog(newRegistration) {
-    const feature = this.features.developer.get('web-ha-messaging');
+    const feature = this.features.developer.get('web-high-availability-messaging');
 
     if (feature && feature.value) {
       if (newRegistration.serviceHostMap &&

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/device/device.js
@@ -143,7 +143,7 @@ const Device = SparkPlugin.extend({
 
   @waitForValue('@')
   determineService(url) {
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       for (const key of Object.keys(this.serviceHostMap.serviceLinks)) {
@@ -170,7 +170,7 @@ const Device = SparkPlugin.extend({
 
   @waitForValue('@')
   getServiceUrl(service) {
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       return this._getServiceUrl(this.serviceHostMap.serviceLinks, service)
@@ -291,7 +291,7 @@ const Device = SparkPlugin.extend({
     if (service === 'idbroker') {
       return Promise.resolve(false);
     }
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       return this._isService(this.serviceHostMap.serviceLinks, service)
@@ -309,7 +309,7 @@ const Device = SparkPlugin.extend({
     if (!uri) {
       return Promise.reject(new Error('`uri` is a required parameter'));
     }
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       if (this._isServiceUrl(this.serviceHostMap.serviceLinks, uri) ||
@@ -339,7 +339,7 @@ const Device = SparkPlugin.extend({
       return Promise.reject(new Error('`service` is a required parameter'));
     }
 
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       const s = this.serviceCatalog.get(service);
@@ -362,7 +362,7 @@ const Device = SparkPlugin.extend({
   },
 
   _isServiceUrl(target, uri) {
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       for (const key of Object.keys(target)) {
@@ -494,7 +494,7 @@ const Device = SparkPlugin.extend({
   },
 
   _updateServiceCatalog(newRegistration) {
-    const feature = this.features.developer.get('web-high-availability-messaging');
+    const feature = this.features.developer.get('web-high-availability');
 
     if (feature && feature.value) {
       if (newRegistration.serviceHostMap &&

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
@@ -25,7 +25,7 @@ export default class ServerErrorInterceptor extends Interceptor {
    */
   onResponseError(options, reason) {
     if ((reason instanceof SparkHttpError.InternalServerError) && options.uri) {
-      const feature = this.spark.internal.device.features.developer.get('web-high-availability-messaging');
+      const feature = this.spark.internal.device.features.developer.get('web-high-availability');
 
       if (feature && feature.value) {
         this.spark.internal.metrics.submitClientMetrics('web-ha', {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/src/interceptors/server-error.js
@@ -25,7 +25,7 @@ export default class ServerErrorInterceptor extends Interceptor {
    */
   onResponseError(options, reason) {
     if ((reason instanceof SparkHttpError.InternalServerError) && options.uri) {
-      const feature = this.spark.internal.device.features.developer.get('web-ha-messaging');
+      const feature = this.spark.internal.device.features.developer.get('web-high-availability-messaging');
 
       if (feature && feature.value) {
         this.spark.internal.metrics.submitClientMetrics('web-ha', {

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -23,12 +23,12 @@ describe('plugin-wdm', () => {
       spark.internal.metrics.submitClientMetrics = sinon.stub();
     });
 
-    describe('when web-high-availability-messaging is enabled', () => {
-      beforeEach('enable web-high-availability-messaging', () => {
+    describe('when web-high-availability is enabled', () => {
+      beforeEach('enable web-high-availability', () => {
         const deviceConfig = cloneDeep(deviceFixture);
 
         deviceConfig.features.developer.push({
-          key: 'web-high-availability-messaging',
+          key: 'web-high-availability',
           val: 'true',
           value: true,
           mutable: true,
@@ -203,7 +203,7 @@ describe('plugin-wdm', () => {
       });
     });
 
-    describe('when web-high-availability-messaging is disabled', () => {
+    describe('when web-high-availability is disabled', () => {
       beforeEach(() => {
         spark.internal.device.set(deviceFixture);
 

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/device.js
@@ -23,12 +23,12 @@ describe('plugin-wdm', () => {
       spark.internal.metrics.submitClientMetrics = sinon.stub();
     });
 
-    describe('when web-ha-messaging is enabled', () => {
-      beforeEach('enable web-ha-messaging', () => {
+    describe('when web-high-availability-messaging is enabled', () => {
+      beforeEach('enable web-high-availability-messaging', () => {
         const deviceConfig = cloneDeep(deviceFixture);
 
         deviceConfig.features.developer.push({
-          key: 'web-ha-messaging',
+          key: 'web-high-availability-messaging',
           val: 'true',
           value: true,
           mutable: true,
@@ -203,7 +203,7 @@ describe('plugin-wdm', () => {
       });
     });
 
-    describe('when web-ha-messaging is disabled', () => {
+    describe('when web-high-availability-messaging is disabled', () => {
       beforeEach(() => {
         spark.internal.device.set(deviceFixture);
 

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
@@ -48,7 +48,7 @@ describe('plugin-wdm', () => {
       interceptor = new ServerErrorInterceptor({spark});
 
       spark.internal.device.features.developer.set([{
-        key: 'web-ha-messaging',
+        key: 'web-high-availability-messaging',
         val: 'true',
         value: true,
         mutable: true,
@@ -57,9 +57,9 @@ describe('plugin-wdm', () => {
     });
 
     describe('#onResponseError()', () => {
-      beforeEach('sets web-ha-messaging to false', () => {
+      beforeEach('sets web-high-availability-messaging to false', () => {
         spark.internal.device.features.developer.set([{
-          key: 'web-ha-messaging',
+          key: 'web-high-availability-messaging',
           val: 'false',
           value: false,
           mutable: true,
@@ -88,9 +88,9 @@ describe('plugin-wdm', () => {
           assert.equal(url, 'http://example.com/a-service');
         }));
       describe('when web-ha-messasing is not enabled', () => {
-        beforeEach('sets web-ha-messaging to false', () => {
+        beforeEach('sets web-high-availability-messaging to false', () => {
           spark.internal.device.features.developer.set([{
-            key: 'web-ha-messaging',
+            key: 'web-high-availability-messaging',
             val: 'false',
             value: false,
             mutable: true,

--- a/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
+++ b/packages/node_modules/@ciscospark/internal-plugin-wdm/test/unit/spec/interceptors/server-error.js
@@ -48,7 +48,7 @@ describe('plugin-wdm', () => {
       interceptor = new ServerErrorInterceptor({spark});
 
       spark.internal.device.features.developer.set([{
-        key: 'web-high-availability-messaging',
+        key: 'web-high-availability',
         val: 'true',
         value: true,
         mutable: true,
@@ -57,9 +57,9 @@ describe('plugin-wdm', () => {
     });
 
     describe('#onResponseError()', () => {
-      beforeEach('sets web-high-availability-messaging to false', () => {
+      beforeEach('sets web-high-availability to false', () => {
         spark.internal.device.features.developer.set([{
-          key: 'web-high-availability-messaging',
+          key: 'web-high-availability',
           val: 'false',
           value: false,
           mutable: true,
@@ -88,9 +88,9 @@ describe('plugin-wdm', () => {
           assert.equal(url, 'http://example.com/a-service');
         }));
       describe('when web-ha-messasing is not enabled', () => {
-        beforeEach('sets web-high-availability-messaging to false', () => {
+        beforeEach('sets web-high-availability to false', () => {
           spark.internal.device.features.developer.set([{
-            key: 'web-high-availability-messaging',
+            key: 'web-high-availability',
             val: 'false',
             value: false,
             mutable: true,

--- a/packages/node_modules/@ciscospark/plugin-phone/src/call.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/call.js
@@ -1013,7 +1013,7 @@ const Call = SparkPlugin.extend({
       const parsed = base64.decode(invitee).split('/');
       const resourceType = parsed[3];
       const id = parsed[4];
-      const feature = this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging');
+      const feature = this.spark.internal.feature.getFeature('developer', 'web-high-availability');
 
       if (resourceType === 'PEOPLE') {
         target = id;

--- a/packages/node_modules/@ciscospark/plugin-phone/src/call.js
+++ b/packages/node_modules/@ciscospark/plugin-phone/src/call.js
@@ -1013,7 +1013,7 @@ const Call = SparkPlugin.extend({
       const parsed = base64.decode(invitee).split('/');
       const resourceType = parsed[3];
       const id = parsed[4];
-      const feature = this.spark.internal.feature.getFeature('developer', 'web-ha-messaging');
+      const feature = this.spark.internal.feature.getFeature('developer', 'web-high-availability-messaging');
 
       if (resourceType === 'PEOPLE') {
         target = id;


### PR DESCRIPTION
# Pull Request Template

## Description
change web-ha-messaging to web-high-availability-messaging.
1. Older version of SDK code is still using the web-ha-messaging toggle.
2. We turn it on, and if they are not using your latest code, then the recent widget or SDK calls will break

Fixes # (issue)

## Type of Change
Fix
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
