### PR TITLE
feat(plugin-messages): refactor to use webook event packaging model

### DIFF
--- a/packages/node_modules/@ciscospark/common/src/constants.js
+++ b/packages/node_modules/@ciscospark/common/src/constants.js
@@ -17,6 +17,7 @@ export const API_ACTIVITY_VERB = {
   ACKNOWLEDGE: 'acknowledge',
   POST: 'post',
   SHARE: 'share',
+  DELETE: 'delete',
   ADD: 'add',
   LEAVE: 'leave',
   ADD_MODERATOR: 'assignModerator',

--- a/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/src/messages.js
@@ -3,7 +3,13 @@
  */
 
 import {
+  WEBEX_EVENT,
+  WEBEX_SPACE_TYPE,
   API_ACTIVITY_VERB,
+  SDK_EVENT_RESOURCE,
+  SDK_EVENT,
+  SDK_EVENT_OWNER,
+  SDK_EVENT_STATUS,
   constructHydraId,
   deconstructHydraId,
   getHydraFiles,
@@ -13,12 +19,9 @@ import {
   Page,
   SparkPlugin
 } from '@ciscospark/spark-core';
-import {isArray} from 'lodash';
+import {isArray, cloneDeep} from 'lodash';
 
 const debug = require('debug')('messages');
-
-const OUTGOING_MESSAGES_CREATED = 'created';
-const INCOMING_MESSAGES_CREATED = 'event:conversation.activity';
 
 /**
  * @typedef {Object} MessageObject
@@ -57,31 +60,68 @@ const Messages = SparkPlugin.extend({
    * @returns {Promise}
    */
   listen() {
-    return this.spark.internal.mercury.connect()
-      .then(() => this.listenTo(
-        this.spark.internal.mercury,
-        INCOMING_MESSAGES_CREATED,
-        (event) => this.onConversationActivityEvent(event)
-      ));
+    // Create a common envelope that we will wrap all events in
+    this.eventEnvelope = {
+      resource: SDK_EVENT_RESOURCE.MESSAGES,
+      // id -- webhook id concept does not correlate to SDK socket event
+      // name -- webhook name concept does not correlate to SDK socket event
+      // targetUrl -- targetUrl concept does not correlate to SDK socket event
+      // secret -- secret concept does not correlate to SDK socket event
+      ownedBy: SDK_EVENT_OWNER.CREATOR,
+      status: SDK_EVENT_STATUS.ACTIVE,
+      created: new Date().toISOString(),
+      data: {}
+    };
+
+    // We need to query for some of the envelope info...
+    this.spark.people.get('me')
+      .then((person) => {
+        this.eventEnvelope.createdBy = person.id;
+        this.eventEnvelope.orgId = person.orgId;
+      }).catch((e) => {
+        console.error(`Unable to get person info for messages \
+          event envelope ${e.message}`);
+      });
+
+    // Register to listen to events
+    return this.spark.internal.mercury.connect().then(() => {
+      this.listenTo(this.spark.internal.mercury,
+        WEBEX_EVENT.TEAMS_ACTIVITY,
+        (event) => this.onWebexApiEvent(event));
+    });
   },
 
   /**
-   * Trigger a "created" event.
+   * Trigger a "messages" event.
    * @param {Object} event
    * @returns {undefined}
    */
-  onConversationActivityEvent(event) {
+  onWebexApiEvent(event) {
     const {activity} = event.data;
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
       case API_ACTIVITY_VERB.SHARE:
       case API_ACTIVITY_VERB.POST:
-        const payload = this.createMessagesEventData(activity);
+        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.CREATED);
 
-        debug(`messages "created" payload: ${JSON.stringify(payload)}`);
-        this.trigger(OUTGOING_MESSAGES_CREATED, payload);
+        if (createdEvent) {
+          debug(`messages "created" payload: \
+            ${JSON.stringify(createdEvent)}`);
+          this.trigger(SDK_EVENT.CREATED, createdEvent);
+        }
         break;
+
+      case API_ACTIVITY_VERB.DELETE:
+        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.DELETED);
+
+        if (deletedEvent) {
+          debug(`messages "deleted" payload: \
+            ${JSON.stringify(deletedEvent)}`);
+          this.trigger(SDK_EVENT.DELETED, deletedEvent);
+        }
+        break;
+
       default: {
         break;
       }
@@ -89,33 +129,51 @@ const Messages = SparkPlugin.extend({
   },
 
   /**
-   * Constructs an event data object for the "created" event,
-   * adhering to Hydra's Message details.
-   * @see https://developer.webex.com/docs/api/v1/messages/get-message-details
+   * Constructs the data object for an event on the messages resource,
+   * adhering to Hydra's Webehook data structure messages.
    * @param {Object} activity from mercury
+   * @param {Object} event type of "webhook" event
    * @returns {Object} constructed event
    */
-  createMessagesEventData(activity) {
-    const roomType =
-      activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+  getMessageEvent(activity, event) {
+    try {
+      const sdkEvent = cloneDeep(this.eventEnvelope);
 
-    const event = {
-      id: constructHydraId(hydraTypes.MESSAGE, activity.id),
-      roomId: constructHydraId(hydraTypes.ROOM, activity.target.id),
-      roomType,
-      text: activity.object.displayName,
-      personId: constructHydraId(hydraTypes.PEOPLE, activity.actor.id),
-      personEmail: activity.actor.emailAddress || activity.actor.entryEmail,
-      created: activity.published
-    };
+      sdkEvent.event = event;
+      sdkEvent.data.created = activity.published;
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.data.roomType =
+        activity.target.tags.includes('ONE_ON_ONE') ?
+          WEBEX_SPACE_TYPE.DIRECT : WEBEX_SPACE_TYPE.GROUP;
+      sdkEvent.data.roomId =
+        constructHydraId(hydraTypes.ROOM, activity.target.id);
+      sdkEvent.data.personId =
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.data.personEmail =
+        activity.actor.emailAddress || activity.actor.entryEmail;
 
-    const files = getHydraFiles(activity);
+      if (event !== SDK_EVENT.DELETED) {
+        const files = getHydraFiles(activity);
 
-    if (files.length) {
-      event.files = files;
+        sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
+        sdkEvent.data.text = activity.object.displayName;
+        if (files.length) {
+          sdkEvent.data.files = files;
+        }
+      }
+      else {
+        sdkEvent.data.id =
+          constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+      }
+
+      return sdkEvent;
     }
+    catch (e) {
+      console.error(`Unable to generate SDK event from mercury \
+        'socket activity for message:${event} event: ${e.message}`);
 
-    return event;
+      return null;
+    }
   },
 
   /**

--- a/packages/node_modules/@ciscospark/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@ciscospark/plugin-messages/test/integration/spec/messages.js
@@ -253,9 +253,10 @@ describe('plugin-messages', function () {
       describe('#listen()', () => {
         [
           'post',
-          'share'
+          'share',
+          'delete'
         ].forEach((verb) => {
-          it(`emits a "created" event when a "${verb}" activity arrives`, () => {
+          it(`emits an event when a "${verb}" activity arrives`, () => {
             const props = {
               verb
             };
@@ -265,6 +266,7 @@ describe('plugin-messages', function () {
             spark.messages.listen()
               .then(() => {
                 spark.messages.on('created', spy);
+                spark.messages.on('deleted', spy);
                 debug(`create mock activity event: ${JSON.stringify(event)}`);
                 spark.internal.mercury._onmessage(event);
 
@@ -364,7 +366,7 @@ function mockActivityEvent(props) {
 function mockActivity(props) {
   const activity = {
     id: '88888888-4444-4444-4444-000000000001',
-    verb: 'post',
+    verb: props.verb,
     actor: {
       id: '88888888-4444-4444-4444-000000000002',
       entryEmail: 'alice@email.com'

--- a/packages/node_modules/samples/browser-socket/app.js
+++ b/packages/node_modules/samples/browser-socket/app.js
@@ -75,6 +75,10 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
             console.log('message created event:');
             console.log(message);
           });
+          webex.messages.on('deleted', (message) => {
+            console.log('message deleted event:');
+            console.log(message);
+          });
         })
         .catch((err) => {
           console.error(`error listening to messages: ${err}`);


### PR DESCRIPTION
# Pull Request Template

## Description

Refactor message events so they use the webhook packaging (similar to the new membership events).   Add a message deleted event

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Register a webhook for messages for a user to a location where you can easily examine the message payloads (ie: https://pipedream.com)
Navigate to https://localhost:8000/browser-socket.   Initialize with the token of the user who registered the webhooks

Send a message to a user in that space.   Compare the payload of the webhook with the payload of the message event, which is printed in the browser console.   Repeat for a message with a file.  Repeat for a deleted message.

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
