### PR TITLE
Feat room events

### DIFF
--- a/packages/node_modules/@ciscospark/common/src/event-envelope.js
+++ b/packages/node_modules/@ciscospark/common/src/event-envelope.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {SDK_EVENT} from '@ciscospark/common';
+
+/**
+ * Creates a 'webhook' envelope to wrap Webex Teams events in
+ * @param {object} webex - sdk object
+ * @param {string} resource - resource to create an envelope for
+ * @returns {object} - Returns a promise of an event envelope object
+ */
+export default function createEventEnvelope(webex, resource) {
+  return new Promise((resolve, reject) => {
+    webex.people.get('me')
+      .then((person) => {
+        resolve({
+          createdBy: person.id,
+          orgId: person.orgId,
+          resource,
+          // id -- webhook id concept does not correlate to SDK socket event
+          // name -- webhook name concept does not correlate to SDK socket event
+          // targetUrl -- targetUrl concept does not correlate to SDK socket event
+          // secret -- secret concept does not correlate to SDK socket event
+          ownedBy: SDK_EVENT.TO_APP.OWNER.CREATOR,
+          status: SDK_EVENT.TO_APP.STATUS.ACTIVE,
+          created: new Date().toISOString(),
+          data: {}
+        });
+      }).catch((e) => {
+        reject(new Error(`Unable to get person info for ${resource} \
+event envelope: ${e.message}`));
+      });
+  });
+}

--- a/packages/node_modules/@ciscospark/common/src/event-envelope.js
+++ b/packages/node_modules/@ciscospark/common/src/event-envelope.js
@@ -22,8 +22,8 @@ export default function createEventEnvelope(webex, resource) {
           // name -- webhook name concept does not correlate to SDK socket event
           // targetUrl -- targetUrl concept does not correlate to SDK socket event
           // secret -- secret concept does not correlate to SDK socket event
-          ownedBy: SDK_EVENT.TO_APP.OWNER.CREATOR,
-          status: SDK_EVENT.TO_APP.STATUS.ACTIVE,
+          ownedBy: SDK_EVENT.EXTERNAL.OWNER.CREATOR,
+          status: SDK_EVENT.EXTERNAL.STATUS.ACTIVE,
           created: new Date().toISOString(),
           data: {}
         });

--- a/packages/node_modules/@webex/common/src/constants.js
+++ b/packages/node_modules/@webex/common/src/constants.js
@@ -1,5 +1,5 @@
 export const SDK_EVENT = {
-  FROM_WEBEX: {
+  INTERNAL: {
     TEAMS_ACTIVITY: 'event:conversation.activity',
     ACTIVITY_FIELD: {
       ACTOR: 'actor',
@@ -25,7 +25,7 @@ export const SDK_EVENT = {
       LOCKED: 'LOCKED'
     }
   },
-  TO_APP: {
+  EXTERNAL: {
     EVENT_TYPE: {
       CREATED: 'created',
       DELETED: 'deleted',

--- a/packages/node_modules/@webex/common/src/constants.js
+++ b/packages/node_modules/@webex/common/src/constants.js
@@ -17,6 +17,7 @@ export const API_ACTIVITY_VERB = {
   ACKNOWLEDGE: 'acknowledge',
   POST: 'post',
   SHARE: 'share',
+  DELETE: 'delete',
   ADD: 'add',
   LEAVE: 'leave',
   ADD_MODERATOR: 'assignModerator',

--- a/packages/node_modules/@webex/common/src/constants.js
+++ b/packages/node_modules/@webex/common/src/constants.js
@@ -1,50 +1,55 @@
-export const WEBEX_EVENT = {
-  TEAMS_ACTIVITY: 'event:conversation.activity'
-};
-
-export const WEBEX_SPACE_TYPE = {
-  DIRECT: 'direct',
-  GROUP: 'group'
-};
-
-export const API_ACTIVITY_FIELD = {
-  ACTOR: 'actor',
-  OBJECT: 'object',
-  TARGET: 'target'
-};
-
-export const API_ACTIVITY_VERB = {
-  ACKNOWLEDGE: 'acknowledge',
-  POST: 'post',
-  SHARE: 'share',
-  DELETE: 'delete',
-  ADD: 'add',
-  LEAVE: 'leave',
-  ADD_MODERATOR: 'assignModerator',
-  REMOVE_MODERATOR: 'unassignModerator',
-  HIDE: 'hide'
-};
-
 export const SDK_EVENT = {
-  CREATED: 'created',
-  DELETED: 'deleted',
-  UPDATED: 'updated',
-  SEEN: 'seen'
-};
-
-export const SDK_EVENT_OWNER = {
-  CREATOR: 'creator',
-  ORG: 'org'
-};
-
-export const SDK_EVENT_STATUS = {
-  ACTIVE: 'active',
-  DISABLED: 'disabled'
-};
-
-export const SDK_EVENT_RESOURCE = {
-  MEMBERSHIPS: 'memberships',
-  MESSAGES: 'messages'
+  FROM_WEBEX: {
+    TEAMS_ACTIVITY: 'event:conversation.activity',
+    ACTIVITY_FIELD: {
+      ACTOR: 'actor',
+      OBJECT: 'object',
+      TARGET: 'target'
+    },
+    ACTIVITY_VERB: {
+      ACKNOWLEDGE: 'acknowledge',
+      CREATE: 'create',
+      POST: 'post',
+      SHARE: 'share',
+      DELETE: 'delete',
+      ADD: 'add',
+      LEAVE: 'leave',
+      ADD_MODERATOR: 'assignModerator',
+      REMOVE_MODERATOR: 'unassignModerator',
+      HIDE: 'hide',
+      UPDATE: 'update'
+    },
+    ACTIVITY_TAG: {
+      HIDDEN: 'HIDDEN',
+      ONE_ON_ONE: 'ONE_ON_ONE',
+      LOCKED: 'LOCKED'
+    }
+  },
+  TO_APP: {
+    EVENT_TYPE: {
+      CREATED: 'created',
+      DELETED: 'deleted',
+      UPDATED: 'updated',
+      SEEN: 'seen'
+    },
+    OWNER: {
+      CREATOR: 'creator',
+      ORG: 'org'
+    },
+    STATUS: {
+      ACTIVE: 'active',
+      DISABLED: 'disabled'
+    },
+    SPACE_TYPE: {
+      DIRECT: 'direct',
+      GROUP: 'group'
+    },
+    RESOURCE: {
+      MEMBERSHIPS: 'memberships',
+      MESSAGES: 'messages',
+      ROOMS: 'rooms'
+    }
+  }
 };
 
 export const hydraTypes = {

--- a/packages/node_modules/@webex/common/src/event-envelope.js
+++ b/packages/node_modules/@webex/common/src/event-envelope.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2015-2019 Cisco Systems, Inc. See LICENSE file.
+ */
+
+import {SDK_EVENT} from '@webex/common';
+
+/**
+ * Creates a 'webhook' envelope to wrap Webex Teams events in
+ * @param {object} webex - sdk object
+ * @param {string} resource - resource to create an envelope for
+ * @returns {object} - Returns a promise of an event envelope object
+ */
+export default function createEventEnvelope(webex, resource) {
+  return new Promise((resolve, reject) => {
+    webex.people.get('me')
+      .then((person) => {
+        resolve({
+          createdBy: person.id,
+          orgId: person.orgId,
+          resource,
+          // id -- webhook id concept does not correlate to SDK socket event
+          // name -- webhook name concept does not correlate to SDK socket event
+          // targetUrl -- targetUrl concept does not correlate to SDK socket event
+          // secret -- secret concept does not correlate to SDK socket event
+          ownedBy: SDK_EVENT.EXTERNAL.OWNER.CREATOR,
+          status: SDK_EVENT.EXTERNAL.STATUS.ACTIVE,
+          created: new Date().toISOString(),
+          data: {}
+        });
+      }).catch((e) => {
+        reject(new Error(`Unable to get person info for ${resource} \
+event envelope: ${e.message}`));
+      });
+  });
+}

--- a/packages/node_modules/@webex/common/src/index.js
+++ b/packages/node_modules/@webex/common/src/index.js
@@ -14,6 +14,7 @@ export {
   proxyEvents,
   transferEvents
 } from './events';
+export {default as createEventEnvelope} from './event-envelope';
 export {default as resolveWith} from './resolve-with';
 export {default as retry} from './retry';
 export {default as tap} from './tap';
@@ -23,14 +24,7 @@ export {default as deprecated} from './deprecated';
 export {default as inBrowser} from './in-browser';
 export {
   hydraTypes,
-  WEBEX_EVENT,
-  WEBEX_SPACE_TYPE,
-  API_ACTIVITY_FIELD,
-  API_ACTIVITY_VERB,
-  SDK_EVENT,
-  SDK_EVENT_OWNER,
-  SDK_EVENT_STATUS,
-  SDK_EVENT_RESOURCE
+  SDK_EVENT
 } from './constants';
 export {
   getHydraFiles,

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -40,14 +40,14 @@ const Memberships = SparkPlugin.extend({
   listen() {
     // Create a common envelope that we will wrap all events in
     return createEventEnvelope(this.spark,
-      SDK_EVENT.TO_APP.RESOURCE.MEMBERSHIPS)
+      SDK_EVENT.EXTERNAL.RESOURCE.MEMBERSHIPS)
       .then((envelope) => {
         this.eventEnvelope = envelope;
 
         // Register to listen to events
         return this.spark.internal.mercury.connect().then(() => {
           this.listenTo(this.spark.internal.mercury,
-            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            SDK_EVENT.INTERNAL.TEAMS_ACTIVITY,
             (event) => this.onWebexApiEvent(event));
         });
       });
@@ -63,49 +63,49 @@ const Memberships = SparkPlugin.extend({
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ADD:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.ADD:
         const membershipCreatedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
+          this.getMembershipEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED);
 
         if (membershipCreatedEventData) {
           debug(`membership "created" payload: \
             ${JSON.stringify(membershipCreatedEventData)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, membershipCreatedEventData);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED, membershipCreatedEventData);
         }
         break;
 
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.LEAVE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.LEAVE:
         const membershipDeletedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.DELETED);
+          this.getMembershipEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED);
 
         if (membershipDeletedEventData) {
           debug(`membership "deleted" payload: \
             ${JSON.stringify(membershipDeletedEventData)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.DELETED, membershipDeletedEventData);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED, membershipDeletedEventData);
         }
         break;
 
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ADD_MODERATOR:
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.REMOVE_MODERATOR:
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.ADD_MODERATOR:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.REMOVE_MODERATOR:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE:
         const membershipUpdatedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED);
+          this.getMembershipEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED);
 
         if (membershipUpdatedEventData) {
           debug(`membership "updated" payload: \
             ${JSON.stringify(membershipUpdatedEventData)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED, membershipUpdatedEventData);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED, membershipUpdatedEventData);
         }
         break;
 
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.ACKNOWLEDGE:
         const membershipSeenEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.SEEN);
+          this.getMembershipEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.SEEN);
 
         if (membershipSeenEventData) {
           debug(`membership "updated" payload: \
             ${JSON.stringify(membershipSeenEventData)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.SEEN, membershipSeenEventData);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.SEEN, membershipSeenEventData);
         }
         break;
 
@@ -130,23 +130,23 @@ const Memberships = SparkPlugin.extend({
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
       sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-      if (activity.verb !== SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE) {
+      if (activity.verb !== SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE) {
         sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.target.id);
         sdkEvent.data.roomType =
-          activity.target.tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
-            SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
-            SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
+          activity.target.tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.ONE_ON_ONE) ?
+            SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT :
+            SDK_EVENT.EXTERNAL.SPACE_TYPE.GROUP;
         sdkEvent.data.isRoomHidden = false; // any activity unhides a space.
       }
       else {
         sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.object.id);
         // currently hidden attribute is only set on 1-1
-        sdkEvent.data.roomType = SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT;
+        sdkEvent.data.roomType = SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT;
         sdkEvent.data.isRoomHidden = true;
       }
-      if (activity.verb !== SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE) {
+      if (activity.verb !== SDK_EVENT.INTERNAL.ACTIVITY_VERB.ACKNOWLEDGE) {
         if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
           sdkEvent.data.isModerator = true;
         }
@@ -158,26 +158,26 @@ const Memberships = SparkPlugin.extend({
       // We won't send it for our new SDK events
       // sdkEvent.data.isMonitor = false;
 
-      if (activity.verb === SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE) {
+      if (activity.verb === SDK_EVENT.INTERNAL.ACTIVITY_VERB.ACKNOWLEDGE) {
         // For a read receipt the person is the "actor" or the one who did the reading
-        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.ACTOR;
+        member = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.ACTOR;
         // The space with the read message is the "target"
-        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+        space = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.TARGET;
         // And the "object" is the message that was last seen
         sdkEvent.data.lastSeenId =
           constructHydraId(hydraTypes.MESSAGE, activity.object.id);
       }
-      else if (activity.verb === SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE) {
+      else if (activity.verb === SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE) {
         // For a hide activity the person is also the "actor"
-        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.ACTOR;
+        member = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.ACTOR;
         // But the space is now the "object"
-        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+        space = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.OBJECT;
       }
       else {
         // For most memberships events the person is the 'object"
-        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+        member = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.OBJECT;
         // and the space is the "target"
-        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+        space = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.TARGET;
       }
 
       sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
@@ -193,7 +193,7 @@ const Memberships = SparkPlugin.extend({
       return sdkEvent;
     }
     catch (e) {
-      console.error(`Unable to generate SDK event from mercury \
+      this.spark.logger.error(`Unable to generate SDK event from mercury \
 'socket activity for memberships:${event} event: ${e.message}`);
 
       return null;

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -129,7 +129,7 @@ const Memberships = SparkPlugin.extend({
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
       if (activity.verb !== SDK_EVENT.INTERNAL.ACTIVITY_VERB.HIDE) {
         sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.target.id);

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -146,14 +146,17 @@ const Memberships = SparkPlugin.extend({
         sdkEvent.data.roomType = SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT;
         sdkEvent.data.isRoomHidden = true;
       }
-      if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
-        sdkEvent.data.isModerator = true;
-      }
-      else {
-        sdkEvent.data.isModerator = false;
+      if (activity.verb !== SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE) {
+        if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
+          sdkEvent.data.isModerator = true;
+        }
+        else {
+          sdkEvent.data.isModerator = false;
+        }
       }
       // This is deprecated but still sent in the webhooks
-      sdkEvent.data.isMonitor = false;
+      // We won't send it for our new SDK events
+      // sdkEvent.data.isMonitor = false;
 
       if (activity.verb === SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE) {
         // For a read receipt the person is the "actor" or the one who did the reading

--- a/packages/node_modules/@webex/plugin-memberships/src/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/src/memberships.js
@@ -5,14 +5,8 @@
 import {SparkPlugin, Page} from '@webex/webex-core';
 import {cloneDeep} from 'lodash';
 import {
-  WEBEX_EVENT,
-  WEBEX_SPACE_TYPE,
-  API_ACTIVITY_FIELD,
-  API_ACTIVITY_VERB,
-  SDK_EVENT_RESOURCE,
   SDK_EVENT,
-  SDK_EVENT_OWNER,
-  SDK_EVENT_STATUS,
+  createEventEnvelope,
   hydraTypes,
   constructHydraId
 } from '@webex/common';
@@ -45,34 +39,18 @@ const Memberships = SparkPlugin.extend({
    */
   listen() {
     // Create a common envelope that we will wrap all events in
-    this.eventEnvelope = {
-      resource: SDK_EVENT_RESOURCE.MEMBERSHIPS,
-      // id -- webhook id concept does not correlate to SDK socket event
-      // name -- webhook name concept does not correlate to SDK socket event
-      // targetUrl -- targetUrl concept does not correlate to SDK socket event
-      // secret -- secret concept does not correlate to SDK socket event
-      ownedBy: SDK_EVENT_OWNER.CREATOR,
-      status: SDK_EVENT_STATUS.ACTIVE,
-      created: new Date().toISOString(),
-      data: {}
-    };
+    return createEventEnvelope(this.spark,
+      SDK_EVENT.TO_APP.RESOURCE.MEMBERSHIPS)
+      .then((envelope) => {
+        this.eventEnvelope = envelope;
 
-    // We need to query for some of the envelope info...
-    this.spark.people.get('me')
-      .then((person) => {
-        this.eventEnvelope.createdBy = person.id;
-        this.eventEnvelope.orgId = person.orgId;
-      }).catch((e) => {
-        console.error(`Unable to get person info for memberships \
-          event envelope ${e.message}`);
+        // Register to listen to events
+        return this.spark.internal.mercury.connect().then(() => {
+          this.listenTo(this.spark.internal.mercury,
+            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            (event) => this.onWebexApiEvent(event));
+        });
       });
-
-    // Register to listen to events
-    return this.spark.internal.mercury.connect().then(() => {
-      this.listenTo(this.spark.internal.mercury,
-        WEBEX_EVENT.TEAMS_ACTIVITY,
-        (event) => this.onWebexApiEvent(event));
-    });
   },
 
   /**
@@ -85,49 +63,49 @@ const Memberships = SparkPlugin.extend({
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
-      case API_ACTIVITY_VERB.ADD:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ADD:
         const membershipCreatedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.CREATED);
+          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
 
         if (membershipCreatedEventData) {
           debug(`membership "created" payload: \
             ${JSON.stringify(membershipCreatedEventData)}`);
-          this.trigger(SDK_EVENT.CREATED, membershipCreatedEventData);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, membershipCreatedEventData);
         }
         break;
 
-      case API_ACTIVITY_VERB.LEAVE:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.LEAVE:
         const membershipDeletedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.DELETED);
+          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.DELETED);
 
         if (membershipDeletedEventData) {
           debug(`membership "deleted" payload: \
             ${JSON.stringify(membershipDeletedEventData)}`);
-          this.trigger(SDK_EVENT.DELETED, membershipDeletedEventData);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.DELETED, membershipDeletedEventData);
         }
         break;
 
-      case API_ACTIVITY_VERB.ADD_MODERATOR:
-      case API_ACTIVITY_VERB.REMOVE_MODERATOR:
-      case API_ACTIVITY_VERB.HIDE:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ADD_MODERATOR:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.REMOVE_MODERATOR:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE:
         const membershipUpdatedEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.UPDATED);
+          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED);
 
         if (membershipUpdatedEventData) {
           debug(`membership "updated" payload: \
             ${JSON.stringify(membershipUpdatedEventData)}`);
-          this.trigger(SDK_EVENT.UPDATED, membershipUpdatedEventData);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED, membershipUpdatedEventData);
         }
         break;
 
-      case API_ACTIVITY_VERB.ACKNOWLEDGE:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE:
         const membershipSeenEventData =
-          this.getMembershipEvent(activity, SDK_EVENT.SEEN);
+          this.getMembershipEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.SEEN);
 
         if (membershipSeenEventData) {
           debug(`membership "updated" payload: \
             ${JSON.stringify(membershipSeenEventData)}`);
-          this.trigger(SDK_EVENT.SEEN, membershipSeenEventData);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.SEEN, membershipSeenEventData);
         }
         break;
 
@@ -144,70 +122,79 @@ const Memberships = SparkPlugin.extend({
    * @returns {Object} constructed event
    */
   getMembershipEvent(activity, event) {
-    const sdkEvent = cloneDeep(this.eventEnvelope);
-    let member;
-    let space;
+    try {
+      const sdkEvent = cloneDeep(this.eventEnvelope);
+      let member;
+      let space;
 
-    sdkEvent.event = event;
-    sdkEvent.data.created = activity.published;
-    sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-    if (activity.verb !== API_ACTIVITY_VERB.HIDE) {
-      sdkEvent.data.roomId =
-      constructHydraId(hydraTypes.ROOM, activity.target.id);
-      sdkEvent.data.roomType =
-        activity.target.tags.includes('ONE_ON_ONE') ?
-          WEBEX_SPACE_TYPE.DIRECT : WEBEX_SPACE_TYPE.GROUP;
-      sdkEvent.data.isRoomHidden = false; // any activity unhides a space.
-    }
-    else {
-      sdkEvent.data.roomId =
-      constructHydraId(hydraTypes.ROOM, activity.object.id);
-      sdkEvent.data.roomType = WEBEX_SPACE_TYPE.DIRECT; // currently hidden attribute is only set on 1-1
-      sdkEvent.data.isRoomHidden = true;
-    }
-    if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
-      sdkEvent.data.isModerator = true;
-    }
-    else {
-      sdkEvent.data.isModerator = false;
-    }
-    sdkEvent.data.isMonitor = false;
+      sdkEvent.event = event;
+      sdkEvent.data.created = activity.published;
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      if (activity.verb !== SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE) {
+        sdkEvent.data.roomId =
+        constructHydraId(hydraTypes.ROOM, activity.target.id);
+        sdkEvent.data.roomType =
+          activity.target.tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
+            SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
+            SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
+        sdkEvent.data.isRoomHidden = false; // any activity unhides a space.
+      }
+      else {
+        sdkEvent.data.roomId =
+        constructHydraId(hydraTypes.ROOM, activity.object.id);
+        // currently hidden attribute is only set on 1-1
+        sdkEvent.data.roomType = SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT;
+        sdkEvent.data.isRoomHidden = true;
+      }
+      if ((activity.object.roomProperties) && (activity.object.roomProperties.isModerator)) {
+        sdkEvent.data.isModerator = true;
+      }
+      else {
+        sdkEvent.data.isModerator = false;
+      }
+      // This is deprecated but still sent in the webhooks
+      sdkEvent.data.isMonitor = false;
 
-    if (activity.verb === API_ACTIVITY_VERB.ACKNOWLEDGE) {
-      // For a read receipt the person is the "actor" or the one who did the reading
-      member = API_ACTIVITY_FIELD.ACTOR;
-      space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
-      // And the "object" is the message that was last seen
-      sdkEvent.data.lastSeenId =
-        constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+      if (activity.verb === SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.ACKNOWLEDGE) {
+        // For a read receipt the person is the "actor" or the one who did the reading
+        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.ACTOR;
+        // The space with the read message is the "target"
+        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+        // And the "object" is the message that was last seen
+        sdkEvent.data.lastSeenId =
+          constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+      }
+      else if (activity.verb === SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.HIDE) {
+        // For a hide activity the person is also the "actor"
+        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.ACTOR;
+        // But the space is now the "object"
+        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+      }
+      else {
+        // For most memberships events the person is the 'object"
+        member = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+        // and the space is the "target"
+        space = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+      }
+
+      sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
+        `${activity[member].entryUUID}:${activity[space].id}`);
+      sdkEvent.data.personId =
+        constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
+      sdkEvent.data.personEmail =
+        activity[member].emailAddress || activity[member].entryEmail;
+      sdkEvent.data.personDisplayName = activity[member].displayName;
+      sdkEvent.data.personOrgId =
+        constructHydraId(hydraTypes.ORGANIZATION, activity[member].orgId);
+
+      return sdkEvent;
     }
-    else if (activity.verb === API_ACTIVITY_VERB.HIDE) {
-      // For a hide activity the person is also the "actor"
-      member = API_ACTIVITY_FIELD.ACTOR;
-      space = API_ACTIVITY_FIELD.OBJECT; // but the space is now the "object"
-    }
-    else {
-      // For most memberships events the person is the 'object" or the one whose membership it is
-      member = API_ACTIVITY_FIELD.OBJECT;
-      space = API_ACTIVITY_FIELD.TARGET; // and the space is the "target"
-    }
-    if ((!activity[member]) || (!activity[space])) {
-      console.error('Unable to generate SDK event ' +
-        'from mercury socket activity');
+    catch (e) {
+      console.error(`Unable to generate SDK event from mercury \
+'socket activity for memberships:${event} event: ${e.message}`);
 
       return null;
     }
-    sdkEvent.data.id = constructHydraId(hydraTypes.MEMBERSHIP,
-      `${activity[member].entryUUID}:${activity[space].id}`);
-    sdkEvent.data.personId =
-      constructHydraId(hydraTypes.PEOPLE, activity[member].entryUUID);
-    sdkEvent.data.personEmail =
-      activity[member].emailAddress || activity[member].entryEmail;
-    sdkEvent.data.personDisplayName = activity[member].displayName;
-    sdkEvent.data.personOrgId =
-      constructHydraId(hydraTypes.ORGANIZATION, activity[member].orgId);
-
-    return sdkEvent;
   },
 
 

--- a/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
@@ -2,52 +2,68 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@webex/internal-plugin-wdm';
-import '@webex/plugin-logger';
-import '@webex/plugin-memberships';
-import '@webex/plugin-rooms';
-import CiscoSpark from '@webex/webex-core';
-import {assert} from '@webex/test-helper-chai';
-import sinon from '@webex/test-helper-sinon';
-import testUsers from '@webex/test-helper-test-users';
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/internal-plugin-mercury';
+import '@ciscospark/plugin-logger';
+import '@ciscospark/plugin-messages';
+import '@ciscospark/plugin-memberships';
+import '@ciscospark/plugin-people';
+import '@ciscospark/plugin-rooms';
+import CiscoSpark from '@ciscospark/spark-core';
+import {
+  SDK_EVENT,
+  hydraTypes,
+  constructHydraId
+} from '@ciscospark/common';
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import testUsers from '@ciscospark/test-helper-test-users';
+
+const debug = require('debug')('memberships');
 
 describe('plugin-memberships', function () {
   this.timeout(60000);
 
-  let spark, user;
+  let spark, user, actor;
 
   before(() => testUsers.create({count: 1})
     .then(([u]) => {
       user = u;
       spark = new CiscoSpark({credentials: user.token});
+      spark.people.get('me')
+        .then((person) => {
+          actor = person;
+          debug('SDK User (Actor) for tests:');
+          debug(`- name: ${actor.displayName}`);
+          debug(`-   id: ${actor.id}`);
+        });
     }));
 
   describe('#memberships', () => {
-    const memberships = [];
-
     let user1;
 
     before(() => testUsers.create({count: 1})
       .then((users) => {
         user1 = users[0];
-      }));
-
-    afterEach(() => Promise.all(memberships.map((membership) => spark.memberships.remove(membership)
-      .catch((reason) => {
-        console.error('Failed to delete membership', reason);
-      })))
-      .then(() => {
-        while (memberships.length) {
-          memberships.pop();
-        }
+        debug('User that memberships are created for:');
+        debug(`- name: ${user1.displayName}`);
+        debug(`-   id: ${constructHydraId(hydraTypes.PEOPLE, user1.id)}`);
       }));
 
     let room;
 
     beforeEach(() => spark.rooms.create({title: 'Cisco Spark Test Room'})
       .then((r) => {
+        debug('Created Cisco Test Room');
         room = r;
       }));
+
+    afterEach(() => {
+      spark.memberships.stopListening();
+      spark.rooms.remove(room)
+        .catch((e) =>
+          spark.logger.error(`Failed to clean up after unit test: ${e}`));
+    });
 
     describe('#create()', () => {
       it('creates a membership by user id', () => spark.memberships.create({
@@ -58,23 +74,75 @@ describe('plugin-memberships', function () {
           assert.isMembership(membership);
         }));
 
-      it('creates a membership by user email', () => spark.memberships.create({
-        roomId: room.id,
-        personEmail: user1.email
-      })
-        .then((membership) => {
-          assert.isMembership(membership);
-        }));
+      it('creates a membership by user email', () => {
+        const created = new Promise((resolve) => {
+          spark.memberships.on('created', (event) => {
+            debug('membership:created event handler called');
+            resolve(event);
+          });
+        });
 
-      it('creates a membership and sets moderator status', () => spark.memberships.create({
-        roomId: room.id,
-        personId: user1.id,
-        isModerator: true
-      })
-        .then((membership) => {
-          assert.isMembership(membership);
-          assert.isTrue(membership.isModerator);
-        }));
+        return spark.memberships.listen()
+          .then(() => spark.memberships.create({
+            roomId: room.id,
+            personEmail: user1.email
+          })
+            .then(async (membership) => {
+              validateMembership(membership);
+              const event = await created;
+
+              validateMembershipEvent(event, membership, actor);
+            }));
+      });
+
+      it('creates a membership and sets moderator status', () => {
+        // "Creating" a member as a moderator actually generates
+        // two events, first a created event (with non-moderator status)
+        // followed by an updated event with isModerator set to true
+        const created = new Promise((resolve) => {
+          spark.memberships.on('created', (event) => {
+            debug('membership:created event handler called');
+            resolve(event);
+          });
+        });
+        const updated = new Promise((resolve) => {
+          spark.memberships.on('updated', (event) => {
+            debug('membership:updated event handler called');
+
+            if (event.data.personId === actor.id) {
+              debug('Setting a member to moderator implicitly sets the ' +
+                'caller of the API to moderator as well. In this test we ' +
+                'will ignore this event');
+
+              return;
+            }
+            resolve(event);
+          });
+        });
+
+        return spark.memberships.listen()
+          .then(() => spark.memberships.create({
+            roomId: room.id,
+            personId: user1.id,
+            isModerator: true
+          })
+            .then(async (m) => {
+              const membership = m;
+
+              validateMembership(membership, true);
+              const event = await created;
+
+              // We expect the isModerator status to be false on create
+              membership.isModerator = false;
+              validateMembershipEvent(event, membership, actor);
+
+              const event2 = await updated;
+
+              // We expect the isModerator status to be false on create
+              membership.isModerator = true;
+              validateMembershipEvent(event2, membership, actor);
+            }));
+      });
     });
 
     describe('#get()', () => {
@@ -211,33 +279,167 @@ describe('plugin-memberships', function () {
     });
 
     describe('#update()', () => {
-      let membership;
+      let membership, room;
 
-      before(() => spark.rooms.create({title: 'Membership E'})
-        .then((room) => spark.memberships.create({
-          roomId: room.id,
-          personId: user1.id
-        }))
-        .then((m) => {
-          membership = m;
-        }));
+      before(() => {
+        // Before setting another user to moderator
+        // We will set the test user to moderator
+        // and wait for that event to arive
+        const updated = new Promise((resolve) => {
+        // updatedPromise = new Promise((resolve) => {
+          spark.memberships.on('updated', (event) => {
+            debug('membership:updated event handler called');
+            spark.memberships.stopListening(); // disable this callback after test
+            resolve(event);
+          });
+        });
 
-      it('updates the membership\'s moderator status', () => {
+        return spark.memberships.listen()
+          .then(() => spark.rooms.create({title: 'Membership E'})
+            .then((r) => {
+              room = r;
+              debug('Membership E Room created');
+              debug(room);
+
+              // First get the SDK users membership
+              return spark.memberships.list({
+                roomId: room.id,
+                personId: actor.id
+              });
+            })
+            .then((membershipList) => {
+              assert.isArray(membershipList.items,
+                'membership list not returned after room creation');
+              assert.equal(membershipList.items.length, 1,
+                'SDK Test user not a member of room just created');
+              const sdkMember = membershipList.items[0];
+
+              validateMembership(sdkMember);
+              debug('SDK User membership after room creation:');
+              debug(sdkMember);
+              sdkMember.isModerator = true;
+
+              // Then update the SDK user to a moderator
+              return spark.memberships.update(sdkMember);
+            })
+            .then(async (m) => {
+              debug('SDK User is now moderator.  Wait for event');
+              validateMembership(m, true);
+              const event = await updated;
+
+              validateMembershipEvent(event, m, actor);
+
+              // Finally, create the user for our test
+              return spark.memberships.create({
+                roomId: room.id,
+                personId: user1.id
+              });
+            })
+            .then((m) => {
+              debug('User 1 Membership created in Membership E');
+              membership = m;
+              validateMembership(membership);
+              debug(membership);
+            })
+            .catch((e) => debug(`membership failed: ${e}`)));
+      });
+
+
+      it('assigns a membership to moderator status', () => {
+        debug('Starting moderator test');
+        debug(membership);
         assert.isFalse(membership.isModerator);
         membership.isModerator = true;
 
-        return spark.memberships.update(membership)
-          .then((m) => {
-            assert.deepEqual(m, membership);
-            assert.isTrue(m.isModerator);
+        const updated = new Promise((resolve) => {
+          spark.memberships.on('updated', (event) => {
+            debug('membership:updated event handler called');
+            resolve(event);
           });
+        });
+
+        return spark.memberships.listen()
+          .then(() => spark.memberships.update(membership)
+            .then(async (m) => {
+              debug('membership updated');
+              assert.deepEqual(m, membership);
+              validateMembership(membership, true);
+              const event = await updated;
+
+              debug(`Original membership to comapre event to: ${JSON.stringify(membership)}`);
+              validateMembershipEvent(event, membership, actor);
+            }));
+      });
+
+      it('revokes a member\'s moderator status', () => {
+        assert.isTrue(membership.isModerator);
+        membership.isModerator = false;
+
+        const updated = new Promise((resolve) => {
+          spark.memberships.on('updated', (event) => {
+            debug('membership:updated event handler called');
+            resolve(event);
+          });
+        });
+
+        return spark.memberships.listen()
+          .then(() => spark.memberships.update(membership)
+            .then(async (m) => {
+              assert.deepEqual(m, membership);
+              validateMembership(membership, false);
+              const event = await updated;
+
+              debug(`Original membership to comapre event to: ${JSON.stringify(membership)}`);
+              validateMembershipEvent(event, membership, actor);
+            }));
       });
     });
 
+    // TODO add a test for hiding a one on one space when that
+    // feature goes GA  (see the one-on-one test in plugin-rooms)
+    /*
+    describe('#hide()', () => {
+      let membership, room;
+
+      // We need a one-on-on space for this test
+      // We create it by sending a message to the test user
+      before(() => {
+        // Ensure that room is a one-on-one object
+        // Ensure that membership is the SDK users membership object
+      });
+      it('hides a space and validates the membership is updated', () => {
+        const updatedEventPromise = new Promise((resolve) => {
+          spark.memberships.on('updated', (event) => {
+            debug('membership:updated event handler called');
+            resolve(event);
+          });
+        });
+
+        return spark.memberships.listen()
+          .then(() => {
+            debug(`Setting room: ${room.title} to hidden..`);
+            room.isRoomHidden = true;
+
+            return spark.rooms.update(room)
+              .catch((reason) => {
+                debug('Failed to hide room: ', reason);
+                assert.fail('Updating room to hidden failed');
+              })
+              .then(async (r) => {
+                debug('room hidden');
+                debug(r);
+                const event = await updatedEventPromise;
+
+                validateMembershipEvent(event, membership, actor);
+              });
+          });
+      });
+    });
+*/
     describe('#remove()', () => {
       let membership, room;
 
-      before(() => spark.rooms.create({title: 'Membership E'})
+      before(() => spark.rooms.create({title: 'Membership F'})
         .then((r) => {
           room = r;
 
@@ -250,15 +452,91 @@ describe('plugin-memberships', function () {
           membership = m;
         }));
 
-      it('deletes a single membership', () => spark.memberships.remove(membership)
-        .then((body) => {
-          assert.notOk(body);
+      it('deletes a single membership', () => {
+        const deleted = new Promise((resolve) => {
+          spark.memberships.on('deleted', (event) => {
+            debug('membership:deleted event handler called');
+            resolve(event);
+          });
+        });
 
-          return spark.memberships.list(room);
-        })
-        .then((memberships) => {
-          assert.notInclude(memberships, membership);
-        }));
+        return spark.memberships.listen()
+          .then(() => spark.memberships.remove(membership)
+            .catch((reason) => {
+              spark.logger.error('Failed to delete membership', reason);
+            }))
+          .then(async (body) => {
+            debug('member deleted');
+            assert.notOk(body);
+
+            return spark.memberships.list(room);
+          })
+          .then(async (memberships) => {
+            assert.notInclude(memberships, membership);
+            const event = await deleted;
+
+            debug(`Original membership to comapre event to: ${JSON.stringify(membership)}`);
+            validateMembershipEvent(event, membership, actor);
+          });
+      });
     });
   });
 });
+
+/**
+ * Validate a Membership object.
+ * @param {Object} membership
+ * @param {Boolean} isModerator -- expected moderator status of member
+ * @returns {void}
+ */
+function validateMembership(membership, isModerator = false) {
+  assert.isDefined(membership);
+  assert.isMembership(membership);
+  assert.equal(membership.isModerator, isModerator,
+    'unexpected isModerator status');
+  debug('membership validated');
+}
+
+/**
+ * Validate a membership event.
+ * @param {Object} event - membership event
+ * @param {Object} membership -- return from the API that generate this event
+ * @param {Object} actor - person object for user who performed action
+ * @returns {void}
+ */
+function validateMembershipEvent(event, membership, actor) {
+  assert.isTrue(event.resource === SDK_EVENT.EXTERNAL.RESOURCE.MEMBERSHIPS,
+    'not a membership event');
+  assert.isDefined(event.event, 'membership event type not set');
+  assert.isDefined(event.created, 'event listener created date not set');
+  assert.equal(event.createdBy, actor.id,
+    'event listener createdBy not set to our actor');
+  assert.equal(event.orgId, actor.orgId,
+    'event listener orgId not === to our actor\'s');
+  assert.equal(event.ownedBy, 'creator', 'event listener not owned by creator');
+  assert.equal(event.status, 'active', 'event listener status not active');
+  assert.equal(event.actorId, actor.id,
+    'event actorId not equal to our actor\'s id');
+
+  // Ensure event data matches data returned from function call
+  // Skip this until we figure out how conversations converts the internal test user UUID
+  assert.equal(event.data.id, membership.id,
+    'event/membership.id not equal');
+  assert.equal(event.data.roomId, membership.roomId,
+    'event/membership.roomId not equal');
+  assert.equal(event.data.personId, membership.personId,
+    'event/membership.personId not equal');
+  assert.equal(event.data.personOrgId, membership.personOrgId,
+    'event/membership.personId not equal');
+  assert.equal(event.data.personEmail, membership.personEmail,
+    'event/membership.personEmail not equal');
+  assert.equal(event.data.personDisplayName, membership.personDisplayName,
+    'event/membership.personDisplayName not equal');
+  assert.equal(event.data.roomType, membership.roomType,
+    'event/membership.roomType not equal');
+  assert.equal(event.data.isModerator, membership.isModerator,
+    'event/membership.isModerator not equal');
+  assert.equal(event.data.isHidden, membership.isHidden,
+    'event/membership.isHidden not equal');
+}
+

--- a/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
+++ b/packages/node_modules/@webex/plugin-memberships/test/integration/spec/memberships.js
@@ -2,22 +2,22 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@ciscospark/internal-plugin-wdm';
-import '@ciscospark/internal-plugin-mercury';
-import '@ciscospark/plugin-logger';
-import '@ciscospark/plugin-messages';
-import '@ciscospark/plugin-memberships';
-import '@ciscospark/plugin-people';
-import '@ciscospark/plugin-rooms';
-import CiscoSpark from '@ciscospark/spark-core';
+import '@webex/internal-plugin-wdm';
+import '@webex/internal-plugin-mercury';
+import '@webex/plugin-logger';
+import '@webex/plugin-messages';
+import '@webex/plugin-memberships';
+import '@webex/plugin-people';
+import '@webex/plugin-rooms';
+import CiscoSpark from '@webex/webex-core';
 import {
   SDK_EVENT,
   hydraTypes,
   constructHydraId
-} from '@ciscospark/common';
-import {assert} from '@ciscospark/test-helper-chai';
-import sinon from '@ciscospark/test-helper-sinon';
-import testUsers from '@ciscospark/test-helper-test-users';
+} from '@webex/common';
+import {assert} from '@webex/test-helper-chai';
+import sinon from '@webex/test-helper-sinon';
+import testUsers from '@webex/test-helper-test-users';
 
 const debug = require('debug')('memberships');
 

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -3,7 +3,13 @@
  */
 
 import {
+  WEBEX_EVENT,
+  WEBEX_SPACE_TYPE,
   API_ACTIVITY_VERB,
+  SDK_EVENT_RESOURCE,
+  SDK_EVENT,
+  SDK_EVENT_OWNER,
+  SDK_EVENT_STATUS,
   constructHydraId,
   deconstructHydraId,
   getHydraFiles,
@@ -12,13 +18,10 @@ import {
 import {
   Page,
   SparkPlugin
-} from '@webex/webex-core';
-import {isArray} from 'lodash';
+} from '@ciscospark/spark-core';
+import {isArray, cloneDeep} from 'lodash';
 
 const debug = require('debug')('messages');
-
-const OUTGOING_MESSAGES_CREATED = 'created';
-const INCOMING_MESSAGES_CREATED = 'event:conversation.activity';
 
 /**
  * @typedef {Object} MessageObject
@@ -57,31 +60,68 @@ const Messages = SparkPlugin.extend({
    * @returns {Promise}
    */
   listen() {
-    return this.spark.internal.mercury.connect()
-      .then(() => this.listenTo(
-        this.spark.internal.mercury,
-        INCOMING_MESSAGES_CREATED,
-        (event) => this.onConversationActivityEvent(event)
-      ));
+    // Create a common envelope that we will wrap all events in
+    this.eventEnvelope = {
+      resource: SDK_EVENT_RESOURCE.MESSAGES,
+      // id -- webhook id concept does not correlate to SDK socket event
+      // name -- webhook name concept does not correlate to SDK socket event
+      // targetUrl -- targetUrl concept does not correlate to SDK socket event
+      // secret -- secret concept does not correlate to SDK socket event
+      ownedBy: SDK_EVENT_OWNER.CREATOR,
+      status: SDK_EVENT_STATUS.ACTIVE,
+      created: new Date().toISOString(),
+      data: {}
+    };
+
+    // We need to query for some of the envelope info...
+    this.spark.people.get('me')
+      .then((person) => {
+        this.eventEnvelope.createdBy = person.id;
+        this.eventEnvelope.orgId = person.orgId;
+      }).catch((e) => {
+        console.error(`Unable to get person info for messages \
+          event envelope ${e.message}`);
+      });
+
+    // Register to listen to events
+    return this.spark.internal.mercury.connect().then(() => {
+      this.listenTo(this.spark.internal.mercury,
+        WEBEX_EVENT.TEAMS_ACTIVITY,
+        (event) => this.onWebexApiEvent(event));
+    });
   },
 
   /**
-   * Trigger a "created" event.
+   * Trigger a "messages" event.
    * @param {Object} event
    * @returns {undefined}
    */
-  onConversationActivityEvent(event) {
+  onWebexApiEvent(event) {
     const {activity} = event.data;
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
       case API_ACTIVITY_VERB.SHARE:
       case API_ACTIVITY_VERB.POST:
-        const payload = this.createMessagesEventData(activity);
+        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.CREATED);
 
-        debug(`messages "created" payload: ${JSON.stringify(payload)}`);
-        this.trigger(OUTGOING_MESSAGES_CREATED, payload);
+        if (createdEvent) {
+          debug(`messages "created" payload: \
+            ${JSON.stringify(createdEvent)}`);
+          this.trigger(SDK_EVENT.CREATED, createdEvent);
+        }
         break;
+
+      case API_ACTIVITY_VERB.DELETE:
+        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.DELETED);
+
+        if (deletedEvent) {
+          debug(`messages "deleted" payload: \
+            ${JSON.stringify(deletedEvent)}`);
+          this.trigger(SDK_EVENT.DELETED, deletedEvent);
+        }
+        break;
+
       default: {
         break;
       }
@@ -89,33 +129,51 @@ const Messages = SparkPlugin.extend({
   },
 
   /**
-   * Constructs an event data object for the "created" event,
-   * adhering to Hydra's Message details.
-   * @see https://developer.webex.com/docs/api/v1/messages/get-message-details
+   * Constructs the data object for an event on the messages resource,
+   * adhering to Hydra's Webehook data structure messages.
    * @param {Object} activity from mercury
+   * @param {Object} event type of "webhook" event
    * @returns {Object} constructed event
    */
-  createMessagesEventData(activity) {
-    const roomType =
-      activity.target.tags.includes('ONE_ON_ONE') ? 'direct' : 'group';
+  getMessageEvent(activity, event) {
+    try {
+      const sdkEvent = cloneDeep(this.eventEnvelope);
 
-    const event = {
-      id: constructHydraId(hydraTypes.MESSAGE, activity.id),
-      roomId: constructHydraId(hydraTypes.ROOM, activity.target.id),
-      roomType,
-      text: activity.object.displayName,
-      personId: constructHydraId(hydraTypes.PEOPLE, activity.actor.id),
-      personEmail: activity.actor.emailAddress || activity.actor.entryEmail,
-      created: activity.published
-    };
+      sdkEvent.event = event;
+      sdkEvent.data.created = activity.published;
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.data.roomType =
+        activity.target.tags.includes('ONE_ON_ONE') ?
+          WEBEX_SPACE_TYPE.DIRECT : WEBEX_SPACE_TYPE.GROUP;
+      sdkEvent.data.roomId =
+        constructHydraId(hydraTypes.ROOM, activity.target.id);
+      sdkEvent.data.personId =
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.data.personEmail =
+        activity.actor.emailAddress || activity.actor.entryEmail;
 
-    const files = getHydraFiles(activity);
+      if (event !== SDK_EVENT.DELETED) {
+        const files = getHydraFiles(activity);
 
-    if (files.length) {
-      event.files = files;
+        sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
+        sdkEvent.data.text = activity.object.displayName;
+        if (files.length) {
+          sdkEvent.data.files = files;
+        }
+      }
+      else {
+        sdkEvent.data.id =
+          constructHydraId(hydraTypes.MESSAGE, activity.object.id);
+      }
+
+      return sdkEvent;
     }
+    catch (e) {
+      console.error(`Unable to generate SDK event from mercury \
+        'socket activity for message:${event} event: ${e.message}`);
 
-    return event;
+      return null;
+    }
   },
 
   /**

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -57,7 +57,7 @@ const Messages = SparkPlugin.extend({
   listen() {
     // Create a common envelope that we will wrap all events in
     return createEventEnvelope(this.spark,
-      SDK_EVENT.TO_APP.RESOURCE.MEMBERSHIPS)
+      SDK_EVENT.TO_APP.RESOURCE.MESSAGES)
       .then((envelope) => {
         this.eventEnvelope = envelope;
 

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -71,6 +71,14 @@ const Messages = SparkPlugin.extend({
   },
 
   /**
+   * Stop listening for message events from the internal socket
+   * @returns {Promise}
+   */
+  unlisten() {
+    return this.stopListening();
+  },
+
+  /**
    * Trigger a "messages" event.
    * @param {Object} event
    * @returns {undefined}

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -71,14 +71,6 @@ const Messages = SparkPlugin.extend({
   },
 
   /**
-   * Stop listening for message events from the internal socket
-   * @returns {Promise}
-   */
-  unlisten() {
-    return this.stopListening();
-  },
-
-  /**
    * Trigger a "messages" event.
    * @param {Object} event
    * @returns {undefined}
@@ -128,7 +120,7 @@ const Messages = SparkPlugin.extend({
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
       sdkEvent.data.roomType =
         activity.target.tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.ONE_ON_ONE) ?
           SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT :
@@ -136,7 +128,7 @@ const Messages = SparkPlugin.extend({
       sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.target.id);
       sdkEvent.data.personId =
-        constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+        constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
       sdkEvent.data.personEmail =
         activity.actor.emailAddress || activity.actor.entryEmail;
 

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -57,14 +57,14 @@ const Messages = SparkPlugin.extend({
   listen() {
     // Create a common envelope that we will wrap all events in
     return createEventEnvelope(this.spark,
-      SDK_EVENT.TO_APP.RESOURCE.MESSAGES)
+      SDK_EVENT.EXTERNAL.RESOURCE.MESSAGES)
       .then((envelope) => {
         this.eventEnvelope = envelope;
 
         // Register to listen to events
         return this.spark.internal.mercury.connect().then(() => {
           this.listenTo(this.spark.internal.mercury,
-            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            SDK_EVENT.INTERNAL.TEAMS_ACTIVITY,
             (event) => this.onWebexApiEvent(event));
         });
       });
@@ -80,24 +80,24 @@ const Messages = SparkPlugin.extend({
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.SHARE:
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.POST:
-        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.SHARE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.POST:
+        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED);
 
         if (createdEvent) {
           debug(`messages "created" payload: \
             ${JSON.stringify(createdEvent)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, createdEvent);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED, createdEvent);
         }
         break;
 
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.DELETE:
-        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.DELETED);
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.DELETE:
+        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED);
 
         if (deletedEvent) {
           debug(`messages "deleted" payload: \
             ${JSON.stringify(deletedEvent)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.DELETED, deletedEvent);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED, deletedEvent);
         }
         break;
 
@@ -122,9 +122,9 @@ const Messages = SparkPlugin.extend({
       sdkEvent.data.created = activity.published;
       sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
       sdkEvent.data.roomType =
-        activity.target.tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
-          SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
-          SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
+        activity.target.tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.ONE_ON_ONE) ?
+          SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT :
+          SDK_EVENT.EXTERNAL.SPACE_TYPE.GROUP;
       sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.target.id);
       sdkEvent.data.personId =
@@ -132,7 +132,7 @@ const Messages = SparkPlugin.extend({
       sdkEvent.data.personEmail =
         activity.actor.emailAddress || activity.actor.entryEmail;
 
-      if (event !== SDK_EVENT.TO_APP.EVENT_TYPE.DELETED) {
+      if (event !== SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
         const files = getHydraFiles(activity);
 
         sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
@@ -149,7 +149,7 @@ const Messages = SparkPlugin.extend({
       return sdkEvent;
     }
     catch (e) {
-      console.error(`Unable to generate SDK event from mercury \
+      this.spark.logger.error(`Unable to generate SDK event from mercury \
 'socket activity for message:${event} event: ${e.message}`);
 
       return null;

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -3,13 +3,8 @@
  */
 
 import {
-  WEBEX_EVENT,
-  WEBEX_SPACE_TYPE,
-  API_ACTIVITY_VERB,
-  SDK_EVENT_RESOURCE,
   SDK_EVENT,
-  SDK_EVENT_OWNER,
-  SDK_EVENT_STATUS,
+  createEventEnvelope,
   constructHydraId,
   deconstructHydraId,
   getHydraFiles,
@@ -61,34 +56,18 @@ const Messages = SparkPlugin.extend({
    */
   listen() {
     // Create a common envelope that we will wrap all events in
-    this.eventEnvelope = {
-      resource: SDK_EVENT_RESOURCE.MESSAGES,
-      // id -- webhook id concept does not correlate to SDK socket event
-      // name -- webhook name concept does not correlate to SDK socket event
-      // targetUrl -- targetUrl concept does not correlate to SDK socket event
-      // secret -- secret concept does not correlate to SDK socket event
-      ownedBy: SDK_EVENT_OWNER.CREATOR,
-      status: SDK_EVENT_STATUS.ACTIVE,
-      created: new Date().toISOString(),
-      data: {}
-    };
+    return createEventEnvelope(this.spark,
+      SDK_EVENT.TO_APP.RESOURCE.MEMBERSHIPS)
+      .then((envelope) => {
+        this.eventEnvelope = envelope;
 
-    // We need to query for some of the envelope info...
-    this.spark.people.get('me')
-      .then((person) => {
-        this.eventEnvelope.createdBy = person.id;
-        this.eventEnvelope.orgId = person.orgId;
-      }).catch((e) => {
-        console.error(`Unable to get person info for messages \
-          event envelope ${e.message}`);
+        // Register to listen to events
+        return this.spark.internal.mercury.connect().then(() => {
+          this.listenTo(this.spark.internal.mercury,
+            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            (event) => this.onWebexApiEvent(event));
+        });
       });
-
-    // Register to listen to events
-    return this.spark.internal.mercury.connect().then(() => {
-      this.listenTo(this.spark.internal.mercury,
-        WEBEX_EVENT.TEAMS_ACTIVITY,
-        (event) => this.onWebexApiEvent(event));
-    });
   },
 
   /**
@@ -101,24 +80,24 @@ const Messages = SparkPlugin.extend({
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
-      case API_ACTIVITY_VERB.SHARE:
-      case API_ACTIVITY_VERB.POST:
-        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.CREATED);
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.SHARE:
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.POST:
+        const createdEvent = this.getMessageEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
 
         if (createdEvent) {
           debug(`messages "created" payload: \
             ${JSON.stringify(createdEvent)}`);
-          this.trigger(SDK_EVENT.CREATED, createdEvent);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, createdEvent);
         }
         break;
 
-      case API_ACTIVITY_VERB.DELETE:
-        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.DELETED);
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.DELETE:
+        const deletedEvent = this.getMessageEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.DELETED);
 
         if (deletedEvent) {
           debug(`messages "deleted" payload: \
             ${JSON.stringify(deletedEvent)}`);
-          this.trigger(SDK_EVENT.DELETED, deletedEvent);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.DELETED, deletedEvent);
         }
         break;
 
@@ -143,8 +122,9 @@ const Messages = SparkPlugin.extend({
       sdkEvent.data.created = activity.published;
       sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
       sdkEvent.data.roomType =
-        activity.target.tags.includes('ONE_ON_ONE') ?
-          WEBEX_SPACE_TYPE.DIRECT : WEBEX_SPACE_TYPE.GROUP;
+        activity.target.tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
+          SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
+          SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
       sdkEvent.data.roomId =
         constructHydraId(hydraTypes.ROOM, activity.target.id);
       sdkEvent.data.personId =
@@ -152,7 +132,7 @@ const Messages = SparkPlugin.extend({
       sdkEvent.data.personEmail =
         activity.actor.emailAddress || activity.actor.entryEmail;
 
-      if (event !== SDK_EVENT.DELETED) {
+      if (event !== SDK_EVENT.TO_APP.EVENT_TYPE.DELETED) {
         const files = getHydraFiles(activity);
 
         sdkEvent.data.id = constructHydraId(hydraTypes.MESSAGE, activity.id);
@@ -170,7 +150,7 @@ const Messages = SparkPlugin.extend({
     }
     catch (e) {
       console.error(`Unable to generate SDK event from mercury \
-        'socket activity for message:${event} event: ${e.message}`);
+'socket activity for message:${event} event: ${e.message}`);
 
       return null;
     }

--- a/packages/node_modules/@webex/plugin-messages/src/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/src/messages.js
@@ -13,7 +13,7 @@ import {
 import {
   Page,
   SparkPlugin
-} from '@ciscospark/spark-core';
+} from '@webex/webex-core';
 import {isArray, cloneDeep} from 'lodash';
 
 const debug = require('debug')('messages');

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -2,18 +2,18 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@ciscospark/internal-plugin-wdm';
-import '@ciscospark/plugin-logger';
-import '@ciscospark/plugin-rooms';
-import '@ciscospark/plugin-people';
-import '@ciscospark/plugin-messages';
-import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
-import {SDK_EVENT} from '@ciscospark/common';
-import {assert} from '@ciscospark/test-helper-chai';
-import sinon from '@ciscospark/test-helper-sinon';
-import testUsers from '@ciscospark/test-helper-test-users';
-import fh from '@ciscospark/test-helper-file';
-import {browserOnly, flaky, nodeOnly} from '@ciscospark/test-helper-mocha';
+import '@webex/internal-plugin-wdm';
+import '@webex/plugin-logger';
+import '@webex/plugin-rooms';
+import '@webex/plugin-people';
+import '@webex/plugin-messages';
+import CiscoSpark, {SparkHttpError} from '@webex/webex-core';
+import {SDK_EVENT} from '@webex/common';
+import {assert} from '@webex/test-helper-chai';
+import sinon from '@webex/test-helper-sinon';
+import testUsers from '@webex/test-helper-test-users';
+import fh from '@webex/test-helper-file';
+import {browserOnly, flaky, nodeOnly} from '@webex/test-helper-mocha';
 
 const debug = require('debug')('messages');
 

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -62,6 +62,8 @@ describe('plugin-messages', function () {
         });
     });
 
+    afterEach(() => spark.messages.stopListening());
+
     describe('#create()', () => {
       it('posts a message in a room and validates the messages:created event', () => {
         let message;
@@ -71,7 +73,6 @@ describe('plugin-messages', function () {
         const created = new Promise((resolve) => {
           spark.messages.on('created', (event) => {
             debug('message created event called');
-            spark.messages.unlisten(); // disable this callback after test
             resolve(event);
           });
         });
@@ -96,7 +97,6 @@ describe('plugin-messages', function () {
         const created = new Promise((resolve) => {
           spark.messages.on('created', (event) => {
             debug('message created event called');
-            spark.messages.unlisten(); // disable this callback after test
             resolve(event);
           });
         });
@@ -142,7 +142,6 @@ describe('plugin-messages', function () {
         const created = new Promise((resolve) => {
           spark.messages.on('created', (event) => {
             debug('message created event called');
-            spark.messages.unlisten(); // disable this callback after test
             resolve(event);
           });
         });
@@ -175,7 +174,6 @@ describe('plugin-messages', function () {
         const created = new Promise((resolve) => {
           spark.messages.on('created', (event) => {
             debug('message created event called');
-            spark.messages.unlisten(); // disable this callback after test
             resolve(event);
           });
         });
@@ -212,7 +210,6 @@ describe('plugin-messages', function () {
         const deleted = new Promise((resolve) => {
           spark.messages.on('deleted', (event) => {
             debug('message deleted event called');
-            spark.messages.unlisten(); // disable this callback after test
             resolve(event);
           });
         });

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -2,42 +2,104 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@webex/internal-plugin-wdm';
-import '@webex/plugin-logger';
-import '@webex/plugin-messages';
-import '@webex/plugin-rooms';
-import CiscoSpark, {SparkHttpError} from '@webex/webex-core';
-import {assert} from '@webex/test-helper-chai';
-import sinon from '@webex/test-helper-sinon';
-import testUsers from '@webex/test-helper-test-users';
-import fh from '@webex/test-helper-file';
-import {browserOnly, flaky, nodeOnly} from '@webex/test-helper-mocha';
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/plugin-logger';
+import '@ciscospark/plugin-rooms';
+import '@ciscospark/plugin-people';
+import '@ciscospark/plugin-messages';
+import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
+import {SDK_EVENT} from '@ciscospark/common';
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import testUsers from '@ciscospark/test-helper-test-users';
+import fh from '@ciscospark/test-helper-file';
+import {browserOnly, flaky, nodeOnly} from '@ciscospark/test-helper-mocha';
+import { validate } from '@ciscospark/common/src/base64';
+import { SSL_OP_EPHEMERAL_RSA } from 'constants';
 
 const debug = require('debug')('messages');
 
 const KNOWN_HOSTED_IMAGE_URL = 'https://download.ciscospark.com/test/photo.png';
+let expectedEvents = [];
 
 describe('plugin-messages', function () {
   this.timeout(60000);
 
   let spark;
+  let actor;
 
   before(() => testUsers.create({count: 1})
     .then(([user]) => {
       spark = new CiscoSpark({credentials: user.token});
+      spark.people.get('me')
+        .then((person) => {
+          actor = person;
+        });
     }));
+
+  // This was an attempt to "drain the event queue" before the test ends
+  // This always completed BEFORE the event handlers were called
+  after('#all done()', () => {
+    console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
+    console.error(`Process existing with ExpectedEvents Array Length: ${expectedEvents.length}`);
+    if (expectedEvents.length) {
+      for (let i = 0; i < expectedEvents.length; i += 1) {
+        console.error(`Never got event for task: ${expectedEvents[i].task}`);
+      }
+    }
+  });
+
+  // This was my "global listener" setup
+  // The outside tests passed when the listen function returned
+  // The inner tests passed when an event handler was called.
+  // describe('#listen()', () => {
+  //   it('registers messages event listeners', () => {
+  //     expectedEvents = [];
+
+  //     return spark.messages.listen()
+  //       .then(() => {
+  //         spark.messages.on('created', (message) => {
+  //           describe('#message:created()', () => {
+  //             it('validates a received message:created event', () => {
+  //               validateMessageEvent(message, expectedEvents, actor);
+  //             });
+  //           });
+  //         });
+  //         spark.messages.on('deleted', (message) => {
+  //           describe('#message:deleted()', () => {
+  //             it('validates a received message:deleted event', () => {
+  //               validateMessageEvent(message, expectedEvents, actor);
+  //             });
+  //           });
+  //         });
+  //       });
+  //   });
+  // });
 
   describe('#messages', () => {
     let room;
 
+    // This is where the room is set up for all the tests
+    // Sending a message here seems unecessary...
+    // Perhaps it somehow validates that the room was properly set up?
     before(() => spark.rooms.create({title: 'Cisco Spark Test Room'})
       .then((r) => {
         room = r;
+        const text = 'First Message';
 
         return spark.messages.create({
           roomId: room.id,
-          text: 'First Message'
-        });
+          text
+        })
+          .then((message) => {
+            validateMessage(message, text);
+            expectedEvents.push({
+              task: text,
+              id: message.id,
+              event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+              data: message
+            });
+          });
       }));
 
     after(() => {
@@ -52,17 +114,38 @@ describe('plugin-messages', function () {
     });
 
     describe('#create()', () => {
-      it('posts a message in a room', () => {
+      it.only('posts a message in a room', (done) => {
         const text = 'A test message';
 
-        return spark.messages.create({
+        spark.messages.listen()
+          .then(() => {
+            spark.messages.on('created', (message) => {
+              debug('Handler was called...');
+              validateMessageEvent(message, expectedEvents, actor);
+              done();
+            });
+
+            // spark.messages.on('deleted', (message) => {
+            //   describe('#message:deleted()', () => {
+            //     it('validates a received message:deleted event', () => {
+            //       validateMessageEvent(message, expectedEvents, actor);
+            //     });
+            //   });
+            // });
+          });
+
+        spark.messages.create({
           roomId: room.id,
           text
         })
           .then((message) => {
-            assert.isDefined(message);
-            assert.isMessage(message);
-            assert.equal(message.text, text);
+            validateMessage(message, text);
+            expectedEvents.push({
+              task: 'posts a message in a room',
+              id: message.id,
+              event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+              data: message
+            });
           });
       });
 
@@ -71,10 +154,13 @@ describe('plugin-messages', function () {
         file: KNOWN_HOSTED_IMAGE_URL
       })
         .then((message) => {
-          assert.property(message, 'files');
-          assert.isDefined(message.files);
-          assert.isArray(message.files);
-          assert.lengthOf(message.files, 1);
+          validateMessage(message, '', 1);
+          expectedEvents.push({
+            task: 'posts a file to a room by specifying the file\'s url',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+            data: message
+          });
         }));
 
       let blob, buffer;
@@ -105,10 +191,13 @@ describe('plugin-messages', function () {
         file: blob
       })
         .then((message) => {
-          assert.property(message, 'files');
-          assert.isDefined(message.files);
-          assert.isArray(message.files);
-          assert.lengthOf(message.files, 1);
+          validateMessage(message, '', 1);
+          expectedEvents.push({
+            task: 'posts a file to a room by directly supplying its blob',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+            data: message
+          });
         }));
 
       // Disabling it gating pipelines because it failes a lot and we get
@@ -118,37 +207,88 @@ describe('plugin-messages', function () {
         file: buffer
       })
         .then((message) => {
-          assert.property(message, 'files');
-          assert.isDefined(message.files);
-          assert.isArray(message.files);
-          assert.lengthOf(message.files, 1);
+          validateMessage(message, '', 1);
+          expectedEvents.push({
+            task: 'posts a file to a room by directly supplying its buffer',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+            data: message
+          });
         }));
+
+      const text = 'A File';
 
       it('posts a file with a message to a room by specifying the file\'s url', () => spark.messages.create({
         roomId: room.id,
         file: KNOWN_HOSTED_IMAGE_URL,
-        text: 'A File'
+        text
       })
         .then((message) => {
-          assert.property(message, 'files');
-          assert.isDefined(message.files);
-          assert.isArray(message.files);
-          assert.lengthOf(message.files, 1);
+          validateMessage(message, text, 1);
+          expectedEvents.push({
+            task: 'posts a file with a message to a room by specifying the file\'s url',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+            data: message
+          });
+        }));
+    });
 
-          assert.property(message, 'text');
+    describe('#remove()', () => {
+      let message;
+      const text = 'This message will be deleted';
+
+      beforeEach(() => spark.messages.create({
+        roomId: room.id,
+        text
+      })
+        .then((m) => {
+          message = m;
+          validateMessage(message, text);
+          expectedEvents.push({
+            task: 'create a messge to delete',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
+            data: message
+          });
+        }));
+
+      it('deletes a single message', () => spark.messages.remove(message)
+        .then((body) => {
+          assert.notOk(body);
+          expectedEvents.push({
+            task: 'deletes a single message',
+            id: message.id,
+            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED,
+            data: message
+          });
+
+          return assert.isRejected(spark.messages.get(message));
+        })
+        .then((reason) => {
+          assert.instanceOf(reason, SparkHttpError.NotFound);
         }));
     });
 
     describe('get()', () => {
       let message;
+      const text = 'A test message';
 
-      before(() => spark.messages.create({
-        roomId: room.id,
-        text: 'A test message'
-      })
-        .then((m) => {
-          message = m;
-        }));
+      before(() => {
+        // The above tests validate all the events
+        // Turn off the event listener for the remainder of the tests
+        spark.messages.off('created');
+        spark.messages.off('deleted');
+        
+        return spark.messages.create({
+          roomId: room.id,
+          text
+        })
+          .then((m) => {
+            message = m;
+            validateMessage(message, text);
+          });
+      });
 
       it('returns a single message', () => spark.messages.get(message)
         .then((m) => {
@@ -157,9 +297,13 @@ describe('plugin-messages', function () {
         }));
     });
 
+
+    // TODO move this function (and its test) to plugin-memberships
     describe('#markAsRead()', () => {
-      before(() => spark.internal.mercury.connect());
-      after(() => spark.internal.mercury.disconnect());
+      // Its not clear why these internal calls were here
+      // The disconnect stopped the event handlers from being called
+      // before(() => spark.internal.mercury.connect());
+      //after(() => spark.internal.mercury.disconnect());
 
       it('marks a message as read', () => {
         const text = 'A test message';
@@ -226,161 +370,169 @@ describe('plugin-messages', function () {
           });
       });
     });
-
-    describe('#remove()', () => {
-      let message;
-
-      beforeEach(() => spark.messages.create({
-        roomId: room.id,
-        text: 'A test message'
-      })
-        .then((m) => {
-          message = m;
-        }));
-
-      it('deletes a single message', () => spark.messages.remove(message)
-        .then((body) => {
-          assert.notOk(body);
-
-          return assert.isRejected(spark.messages.get(message));
-        })
-        .then((reason) => {
-          assert.instanceOf(reason, SparkHttpError.NotFound);
-        }));
-    });
-
-    describe('events', () => {
-      describe('#listen()', () => {
-        [
-          'post',
-          'share',
-          'delete'
-        ].forEach((verb) => {
-          it(`emits an event when a "${verb}" activity arrives`, () => {
-            const props = {
-              verb
-            };
-            const event = mockActivityEvent(props);
-            const spy = sinon.spy();
-
-            spark.messages.listen()
-              .then(() => {
-                spark.messages.on('created', spy);
-                spark.messages.on('deleted', spy);
-                debug(`create mock activity event: ${JSON.stringify(event)}`);
-                spark.internal.mercury._onmessage(event);
-
-                return Promise.resolve()
-                  .then(() => {
-                    assert.calledOnce(spy);
-                  });
-              });
-          });
-        });
-      });
-
-      describe('#createMessagesEventData', () => {
-        [
-          {
-            tags: ['ONE_ON_ONE'],
-            roomType: 'direct'
-          },
-          {
-            tags: [],
-            roomType: 'group'
-          }
-        ].forEach((input) => {
-          it(`creates a messages event for a ${input.roomType} room`, () => {
-            const props = {
-              target: {
-                tags: input.tags
-              }
-            };
-            const activity = mockActivity(props);
-            const event = spark.messages.createMessagesEventData(activity);
-
-            debug(`messages event created: ${JSON.stringify(event)}`);
-
-            assert.isDefined(event.id);
-            assert.isDefined(event.roomId);
-            assert.isTrue(event.roomType === input.roomType);
-            assert.isTrue(event.text === activity.object.displayName);
-            assert.isDefined(event.personId);
-            assert.isDefined(event.personEmail);
-            assert.isDefined(event.created);
-          });
-        });
-
-        it('creates a messages event with files', () => {
-          const additionalProps = {
-            object: {
-              files: {
-                items: [
-                  {
-                    displayName: 'file1.png'
-                  },
-                  {
-                    displayName: 'file2.txt'
-                  }
-                ]
-              }
-            }
-          };
-          const activity = mockActivity(additionalProps);
-          const event = spark.messages.createMessagesEventData(activity);
-
-          assert.isArray(event.files);
-          assert.isTrue(event.files.length === 2);
-          event.files.forEach((file) => {
-            assert.isTrue(file.startsWith('https://api.ciscospark.com/v1/contents/'));
-          });
-        });
-      });
-    });
   });
+
+
+//   These were attempts to "drain the event stack"
+//   describe('#waitForEvents()', () => {
+//     const secondsToWait = 5;
+
+//     it(`waits for ${secondsToWait} seconds for expected events`, (done) => {
+//       process.nextTick(async () => {
+//         console.error(`Sleeping with ExpectedEvents Array Length: ${expectedEvents.length}`);
+//         await sleep(1000);
+//         console.error(`Woke with ExpectedEvents Array Length: ${expectedEvents.length}`);
+//         if (expectedEvents.length) {
+//           for (let i = 0; i < expectedEvents.length; i += 1) {
+//             console.error(`Never got event for task: ${expectedEvents[i].task}`);
+//           }
+//         }
+//         else {
+//           console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
+//         }
+//         done();
+//       });
+// //      setTimeout(() => {
+//       //   done();
+//       // }, secondsToWait * 1000); // timeout with an error in one second
+//     });
+//   });
+
+  // describe('#waitForEvents()', () => {
+  //   const secondsToWait = 5;
+
+  //   it(`waits for ${secondsToWait} seconds for expected events`, (done) => {
+  //     this.timeout(secondsToWait * 1000);
+
+  //     waitForEventsToDrain(expectedEvents, secondsToWait)
+  //       .then(() => {
+  //         console.error('Wait test resolved');
+  //         done();
+  //       }).catch(() => {
+  //         console.error('Wait test rejected');
+  //         done();
+  //       });
+  //   });
+  // });
 });
 
-/**
- * Create a mock activity event.
- * Add and override properties to customize the default activity.
- * @param {Object} props
- * @returns {Object} activity
- */
-function mockActivityEvent(props) {
-  return {
-    data: {
-      data: {
-        activity: mockActivity(props),
-        eventType: 'conversation.activity'
-      }
+// Since I could not "drain the event stack" inside of the test framework.
+// this simply prints out data about the state of the stack when the process exits
+process.on('exit', () => {
+  console.error(`Process existing with ExpectedEvents Array Length: ${expectedEvents.length}`);
+  if (expectedEvents.length) {
+    for (let i = 0; i < expectedEvents.length; i += 1) {
+      console.error(`Never got event for task: ${expectedEvents[i].task}`);
     }
-  };
+  }
+});
+
+// These were also attempts to "give up the processor" to see if we could
+// get the event handlers called while the tests were running
+
+// function sleep(ms) {
+//   return new Promise((resolve) => setTimeout(resolve, ms));
+// }
+
+// async function waitForEventsToDrain(expectedEvents, secondsToWait) {
+//   return new Promise(async (resolve, reject) => {
+//     let numSecs = 0;
+
+//     console.error('Checking if we need to wait for events before ending...');
+//     while ((expectedEvents.length < 10) && (numSecs < secondsToWait)) {
+//       console.error(`Waiting ${secondsToWait - numSecs} seconds for ${expectedEvents.length} more events...`);
+//       // Wait for exxpected events to arrive
+//       // eslint-disable-next-line no-await-in-loop
+//       await sleep(1000);
+//       numSecs += 1;
+//     }
+//     if (expectedEvents.length) {
+//       for (let i = 0; i < expectedEvents.length; i += 1) {
+//         console.error(`Never got event for task: ${expectedEvents[i].task}`);
+//       }
+//       reject(new Error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`));
+//     }
+//     else {
+//       console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
+//       resolve();
+//     }
+//   });
+// }
+
+/**
+ * Validate a Message object.
+ * @param {Object} message
+ * @param {String} text -- optional message text to check
+ * @param {Boolean} numFiles
+ * @returns {void}
+ */
+function validateMessage(message, text = '', numFiles = 0) {
+  assert.isDefined(message);
+  assert.isMessage(message);
+  if (text) {
+    assert.equal(message.text, text);
+  }
+  if (numFiles) {
+    assert.property(message, 'files');
+    assert.isDefined(message.files);
+    assert.isArray(message.files);
+    assert.lengthOf(message.files, numFiles);
+  }
 }
 
 /**
- * Create a mock activity.
- * Add and override properties to customize the default activity.
- * @param {Object} props
- * @returns {Object} activity
+ * Validate a Message evet.
+ * @param {Object} event - message event
+ * @param {Array} expectedEvents -- array of expected events
+ * @param {Object} actor - person object for user who performed action
+ * @returns {void}
  */
-function mockActivity(props) {
-  const activity = {
-    id: '88888888-4444-4444-4444-000000000001',
-    verb: props.verb,
-    actor: {
-      id: '88888888-4444-4444-4444-000000000002',
-      entryEmail: 'alice@email.com'
-    },
-    object: {
-      displayName: 'hi'
-    },
-    target: {
-      tags: [
-        'ONE_ON_ONE'
-      ]
-    },
-    published: Date.now()
-  };
+function validateMessageEvent(event, expectedEvents, actor) {
+  console.error(`Validating Event: ExpectedEvents Array Length: ${expectedEvents.length}`);
+  // Inspect the event "webhook" envelope
+  assert.isTrue(event.resource === SDK_EVENT.EXTERNAL.RESOURCE.MESSAGES);
+  assert.isDefined(event.event);
+  assert.isDefined(event.created);
+  assert.equal(event.createdBy, actor.id);
+  assert.equal(event.orgId, actor.orgId);
+  assert.equal(event.ownedBy, 'creator');
+  assert.equal(event.status, 'active');
+  assert.equal(event.actorId, actor.id);
 
-  return Object.assign(activity, props);
+  // Match this event up to a return value from a previous function call
+  assert.isDefined(event.data.id);
+  const msgIdx = expectedEvents.findIndex((x) =>
+    (x.id === event.data.id) && (x.event === event.event));
+
+  if (msgIdx < 0) {
+    // Not every event is being tracked
+    return;
+  }
+  const expectedEvent = expectedEvents[msgIdx];
+
+  expectedEvents.splice(msgIdx, 1);
+  console.error(`After splice: ExpectedEvents Array Length: ${expectedEvents.length}`);
+
+  // Ensure event data matches data returned from function call
+  assert.equal(event.data.roomId, expectedEvent.data.roomId);
+  assert.equal(event.data.personId, expectedEvent.data.personId);
+  assert.equal(event.data.personEmail, expectedEvent.data.personEmail);
+  assert.equal(event.data.roomType, expectedEvent.data.roomType);
+  if (event.event === SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
+    return;
+  }
+  if (expectedEvent.data.text) {
+    assert.equal(event.data.text, expectedEvent.data.text);
+  }
+  if (expectedEvent.data.files) {
+    assert.isArray(event.data.files);
+    assert.isArray(expectedEvent.data.files);
+    assert.equal(event.data.files.length, expectedEvent.data.files.length);
+    for (let i = 0; i < expectedEvent.data.files.length; i += 1) {
+      // The gateway returned by the API is apialpha.ciscospark.com
+      // The gateway returned in the event is api.ciscospark.com -- expected?
+      assert.equal(event.data.files[i].substr(event.data.files[i].lastIndexOf('/') + 1),
+        expectedEvent.data.files[i].substr(expectedEvent.data.files[i].lastIndexOf('/') + 1));
+    }
+  }
 }

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -14,13 +14,10 @@ import sinon from '@ciscospark/test-helper-sinon';
 import testUsers from '@ciscospark/test-helper-test-users';
 import fh from '@ciscospark/test-helper-file';
 import {browserOnly, flaky, nodeOnly} from '@ciscospark/test-helper-mocha';
-import { validate } from '@ciscospark/common/src/base64';
-import { SSL_OP_EPHEMERAL_RSA } from 'constants';
 
 const debug = require('debug')('messages');
 
 const KNOWN_HOSTED_IMAGE_URL = 'https://download.ciscospark.com/test/photo.png';
-let expectedEvents = [];
 
 describe('plugin-messages', function () {
   this.timeout(60000);
@@ -37,51 +34,9 @@ describe('plugin-messages', function () {
         });
     }));
 
-  // This was an attempt to "drain the event queue" before the test ends
-  // This always completed BEFORE the event handlers were called
-  after('#all done()', () => {
-    console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
-    console.error(`Process existing with ExpectedEvents Array Length: ${expectedEvents.length}`);
-    if (expectedEvents.length) {
-      for (let i = 0; i < expectedEvents.length; i += 1) {
-        console.error(`Never got event for task: ${expectedEvents[i].task}`);
-      }
-    }
-  });
-
-  // This was my "global listener" setup
-  // The outside tests passed when the listen function returned
-  // The inner tests passed when an event handler was called.
-  // describe('#listen()', () => {
-  //   it('registers messages event listeners', () => {
-  //     expectedEvents = [];
-
-  //     return spark.messages.listen()
-  //       .then(() => {
-  //         spark.messages.on('created', (message) => {
-  //           describe('#message:created()', () => {
-  //             it('validates a received message:created event', () => {
-  //               validateMessageEvent(message, expectedEvents, actor);
-  //             });
-  //           });
-  //         });
-  //         spark.messages.on('deleted', (message) => {
-  //           describe('#message:deleted()', () => {
-  //             it('validates a received message:deleted event', () => {
-  //               validateMessageEvent(message, expectedEvents, actor);
-  //             });
-  //           });
-  //         });
-  //       });
-  //   });
-  // });
-
   describe('#messages', () => {
     let room;
 
-    // This is where the room is set up for all the tests
-    // Sending a message here seems unecessary...
-    // Perhaps it somehow validates that the room was properly set up?
     before(() => spark.rooms.create({title: 'Cisco Spark Test Room'})
       .then((r) => {
         room = r;
@@ -93,12 +48,6 @@ describe('plugin-messages', function () {
         })
           .then((message) => {
             validateMessage(message, text);
-            expectedEvents.push({
-              task: text,
-              id: message.id,
-              event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-              data: message
-            });
           });
       }));
 
@@ -114,56 +63,59 @@ describe('plugin-messages', function () {
     });
 
     describe('#create()', () => {
-      it.only('posts a message in a room', (done) => {
+      it('posts a message in a room and validates the messages:created event', () => {
+        let message;
+
+        // "Block" this test with a promise that will
+        // resolve after the messages:created arrives.
+        const created = new Promise((resolve) => {
+          spark.messages.on('created', (event) => {
+            debug('message created event called');
+            spark.messages.unlisten(); // disable this callback after test
+            resolve(event);
+          });
+        });
+
         const text = 'A test message';
 
-        spark.messages.listen()
-          .then(() => {
-            spark.messages.on('created', (message) => {
-              debug('Handler was called...');
-              validateMessageEvent(message, expectedEvents, actor);
-              done();
-            });
+        return spark.messages.listen()
+          .then(() => spark.messages.create({
+            roomId: room.id,
+            text
+          })
+            .then(async (m) => {
+              message = m;
+              validateMessage(message, text);
+              const event = await created;
 
-            // spark.messages.on('deleted', (message) => {
-            //   describe('#message:deleted()', () => {
-            //     it('validates a received message:deleted event', () => {
-            //       validateMessageEvent(message, expectedEvents, actor);
-            //     });
-            //   });
-            // });
-          });
-
-        spark.messages.create({
-          roomId: room.id,
-          text
-        })
-          .then((message) => {
-            validateMessage(message, text);
-            expectedEvents.push({
-              task: 'posts a message in a room',
-              id: message.id,
-              event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-              data: message
-            });
-          });
+              validateMessageEvent(event, message, actor);
+            }));
       });
 
-      it('posts a file to a room by specifying the file\'s url', () => spark.messages.create({
-        roomId: room.id,
-        file: KNOWN_HOSTED_IMAGE_URL
-      })
-        .then((message) => {
-          validateMessage(message, '', 1);
-          expectedEvents.push({
-            task: 'posts a file to a room by specifying the file\'s url',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-            data: message
+      it('posts a file to a room by specifying the file\'s url and validates the event', () => {
+        const created = new Promise((resolve) => {
+          spark.messages.on('created', (event) => {
+            debug('message created event called');
+            spark.messages.unlisten(); // disable this callback after test
+            resolve(event);
           });
-        }));
+        });
+
+        return spark.messages.listen()
+          .then(() => spark.messages.create({
+            roomId: room.id,
+            file: KNOWN_HOSTED_IMAGE_URL
+          })
+            .then(async (message) => {
+              validateMessage(message);
+              const event = await created;
+
+              validateMessageEvent(event, message, actor);
+            }));
+      });
 
       let blob, buffer;
+      const text = 'A File';
 
       browserOnly(before)(() => fh.fetch('sample-image-small-one.png')
         .then((file) => {
@@ -186,52 +138,61 @@ describe('plugin-messages', function () {
           buffer = file;
         }));
 
-      browserOnly(it)('posts a file to a room by directly supplying its blob', () => spark.messages.create({
-        roomId: room.id,
-        file: blob
-      })
-        .then((message) => {
-          validateMessage(message, '', 1);
-          expectedEvents.push({
-            task: 'posts a file to a room by directly supplying its blob',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-            data: message
+      browserOnly(it)('posts a file to a room by directly supplying its blob and validates the event', () => {
+        const created = new Promise((resolve) => {
+          spark.messages.on('created', (event) => {
+            debug('message created event called');
+            spark.messages.unlisten(); // disable this callback after test
+            resolve(event);
           });
-        }));
+        });
+
+        return spark.messages.listen()
+          .then(() => spark.messages.create({
+            roomId: room.id,
+            file: blob,
+            text
+          })
+            .then(async (message) => {
+              validateMessage(message);
+              const event = await created;
+
+              validateMessageEvent(event, message, actor);
+            }));
+      });
 
       // Disabling it gating pipelines because it failes a lot and we get
       // mostly adequate coverage via blob upload
-      flaky(it, process.env.SKIP_FLAKY_TESTS)('posts a file to a room by directly supplying its buffer', () => spark.messages.create({
+      flaky(it, process.env.SKIP_FLAKY_TESTS)('posts a file to a room by directly supplying its buffer and validates the event', () => spark.messages.create({
         roomId: room.id,
         file: buffer
       })
         .then((message) => {
           validateMessage(message, '', 1);
-          expectedEvents.push({
-            task: 'posts a file to a room by directly supplying its buffer',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-            data: message
-          });
         }));
 
-      const text = 'A File';
-
-      it('posts a file with a message to a room by specifying the file\'s url', () => spark.messages.create({
-        roomId: room.id,
-        file: KNOWN_HOSTED_IMAGE_URL,
-        text
-      })
-        .then((message) => {
-          validateMessage(message, text, 1);
-          expectedEvents.push({
-            task: 'posts a file with a message to a room by specifying the file\'s url',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-            data: message
+      it('posts a file with a message to a room by specifying the file\'s url and validates the event', () => {
+        const created = new Promise((resolve) => {
+          spark.messages.on('created', (event) => {
+            debug('message created event called');
+            spark.messages.unlisten(); // disable this callback after test
+            resolve(event);
           });
-        }));
+        });
+
+        return spark.messages.listen()
+          .then(() => spark.messages.create({
+            roomId: room.id,
+            file: KNOWN_HOSTED_IMAGE_URL,
+            text
+          })
+            .then(async (message) => {
+              validateMessage(message);
+              const event = await created;
+
+              validateMessageEvent(event, message, actor);
+            }));
+      });
     });
 
     describe('#remove()', () => {
@@ -244,30 +205,32 @@ describe('plugin-messages', function () {
       })
         .then((m) => {
           message = m;
-          validateMessage(message, text);
-          expectedEvents.push({
-            task: 'create a messge to delete',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED,
-            data: message
-          });
+          validateMessage(m, text);
         }));
 
-      it('deletes a single message', () => spark.messages.remove(message)
-        .then((body) => {
-          assert.notOk(body);
-          expectedEvents.push({
-            task: 'deletes a single message',
-            id: message.id,
-            event: SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED,
-            data: message
+      it('deletes a single message and validates the message:deleted event', () => {
+        const deleted = new Promise((resolve) => {
+          spark.messages.on('deleted', (event) => {
+            debug('message deleted event called');
+            spark.messages.unlisten(); // disable this callback after test
+            resolve(event);
           });
+        });
 
-          return assert.isRejected(spark.messages.get(message));
-        })
-        .then((reason) => {
-          assert.instanceOf(reason, SparkHttpError.NotFound);
-        }));
+        return spark.messages.listen()
+          .then(() => spark.messages.remove(message)
+            .then((body) => {
+              assert.notOk(body);
+
+              return assert.isRejected(spark.messages.get(message));
+            })
+            .then(async (reason) => {
+              assert.instanceOf(reason, SparkHttpError.NotFound);
+              const event = await deleted;
+
+              validateMessageEvent(event, message, actor);
+            }));
+      });
     });
 
     describe('get()', () => {
@@ -279,7 +242,7 @@ describe('plugin-messages', function () {
         // Turn off the event listener for the remainder of the tests
         spark.messages.off('created');
         spark.messages.off('deleted');
-        
+
         return spark.messages.create({
           roomId: room.id,
           text
@@ -300,11 +263,6 @@ describe('plugin-messages', function () {
 
     // TODO move this function (and its test) to plugin-memberships
     describe('#markAsRead()', () => {
-      // Its not clear why these internal calls were here
-      // The disconnect stopped the event handlers from being called
-      // before(() => spark.internal.mercury.connect());
-      //after(() => spark.internal.mercury.disconnect());
-
       it('marks a message as read', () => {
         const text = 'A test message';
 
@@ -323,8 +281,6 @@ describe('plugin-messages', function () {
     });
 
     describe('#list()', () => {
-      let room;
-
       before(() => spark.rooms.create({
         title: 'Room List Test'
       })
@@ -371,93 +327,8 @@ describe('plugin-messages', function () {
       });
     });
   });
-
-
-//   These were attempts to "drain the event stack"
-//   describe('#waitForEvents()', () => {
-//     const secondsToWait = 5;
-
-//     it(`waits for ${secondsToWait} seconds for expected events`, (done) => {
-//       process.nextTick(async () => {
-//         console.error(`Sleeping with ExpectedEvents Array Length: ${expectedEvents.length}`);
-//         await sleep(1000);
-//         console.error(`Woke with ExpectedEvents Array Length: ${expectedEvents.length}`);
-//         if (expectedEvents.length) {
-//           for (let i = 0; i < expectedEvents.length; i += 1) {
-//             console.error(`Never got event for task: ${expectedEvents[i].task}`);
-//           }
-//         }
-//         else {
-//           console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
-//         }
-//         done();
-//       });
-// //      setTimeout(() => {
-//       //   done();
-//       // }, secondsToWait * 1000); // timeout with an error in one second
-//     });
-//   });
-
-  // describe('#waitForEvents()', () => {
-  //   const secondsToWait = 5;
-
-  //   it(`waits for ${secondsToWait} seconds for expected events`, (done) => {
-  //     this.timeout(secondsToWait * 1000);
-
-  //     waitForEventsToDrain(expectedEvents, secondsToWait)
-  //       .then(() => {
-  //         console.error('Wait test resolved');
-  //         done();
-  //       }).catch(() => {
-  //         console.error('Wait test rejected');
-  //         done();
-  //       });
-  //   });
-  // });
 });
 
-// Since I could not "drain the event stack" inside of the test framework.
-// this simply prints out data about the state of the stack when the process exits
-process.on('exit', () => {
-  console.error(`Process existing with ExpectedEvents Array Length: ${expectedEvents.length}`);
-  if (expectedEvents.length) {
-    for (let i = 0; i < expectedEvents.length; i += 1) {
-      console.error(`Never got event for task: ${expectedEvents[i].task}`);
-    }
-  }
-});
-
-// These were also attempts to "give up the processor" to see if we could
-// get the event handlers called while the tests were running
-
-// function sleep(ms) {
-//   return new Promise((resolve) => setTimeout(resolve, ms));
-// }
-
-// async function waitForEventsToDrain(expectedEvents, secondsToWait) {
-//   return new Promise(async (resolve, reject) => {
-//     let numSecs = 0;
-
-//     console.error('Checking if we need to wait for events before ending...');
-//     while ((expectedEvents.length < 10) && (numSecs < secondsToWait)) {
-//       console.error(`Waiting ${secondsToWait - numSecs} seconds for ${expectedEvents.length} more events...`);
-//       // Wait for exxpected events to arrive
-//       // eslint-disable-next-line no-await-in-loop
-//       await sleep(1000);
-//       numSecs += 1;
-//     }
-//     if (expectedEvents.length) {
-//       for (let i = 0; i < expectedEvents.length; i += 1) {
-//         console.error(`Never got event for task: ${expectedEvents[i].task}`);
-//       }
-//       reject(new Error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`));
-//     }
-//     else {
-//       console.error(`Ending with ExpectedEvents Array Length: ${expectedEvents.length}`);
-//       resolve();
-//     }
-//   });
-// }
 
 /**
  * Validate a Message object.
@@ -478,61 +349,59 @@ function validateMessage(message, text = '', numFiles = 0) {
     assert.isArray(message.files);
     assert.lengthOf(message.files, numFiles);
   }
+  debug('message validated');
 }
 
 /**
- * Validate a Message evet.
+ * Validate a Message event.
  * @param {Object} event - message event
- * @param {Array} expectedEvents -- array of expected events
+ * @param {Object} message -- return from the API that generate this event
  * @param {Object} actor - person object for user who performed action
  * @returns {void}
  */
-function validateMessageEvent(event, expectedEvents, actor) {
-  console.error(`Validating Event: ExpectedEvents Array Length: ${expectedEvents.length}`);
-  // Inspect the event "webhook" envelope
-  assert.isTrue(event.resource === SDK_EVENT.EXTERNAL.RESOURCE.MESSAGES);
-  assert.isDefined(event.event);
-  assert.isDefined(event.created);
-  assert.equal(event.createdBy, actor.id);
-  assert.equal(event.orgId, actor.orgId);
-  assert.equal(event.ownedBy, 'creator');
-  assert.equal(event.status, 'active');
-  assert.equal(event.actorId, actor.id);
-
-  // Match this event up to a return value from a previous function call
-  assert.isDefined(event.data.id);
-  const msgIdx = expectedEvents.findIndex((x) =>
-    (x.id === event.data.id) && (x.event === event.event));
-
-  if (msgIdx < 0) {
-    // Not every event is being tracked
-    return;
-  }
-  const expectedEvent = expectedEvents[msgIdx];
-
-  expectedEvents.splice(msgIdx, 1);
-  console.error(`After splice: ExpectedEvents Array Length: ${expectedEvents.length}`);
+function validateMessageEvent(event, message, actor) {
+  assert.isTrue(event.resource === SDK_EVENT.EXTERNAL.RESOURCE.MESSAGES,
+    'not a message event');
+  assert.isDefined(event.event, 'message event type not set');
+  assert.isDefined(event.created, 'event listener created date not set');
+  assert.equal(event.createdBy, actor.id,
+    'event listener createdBy not set to our actor');
+  assert.equal(event.orgId, actor.orgId,
+    'event listener orgId not === to our actor\'s');
+  assert.equal(event.ownedBy, 'creator', 'event listener not owned by creator');
+  assert.equal(event.status, 'active', 'event listener status not active');
+  assert.equal(event.actorId, actor.id,
+    'event actorId not equal to our actor\'s id');
 
   // Ensure event data matches data returned from function call
-  assert.equal(event.data.roomId, expectedEvent.data.roomId);
-  assert.equal(event.data.personId, expectedEvent.data.personId);
-  assert.equal(event.data.personEmail, expectedEvent.data.personEmail);
-  assert.equal(event.data.roomType, expectedEvent.data.roomType);
+  assert.equal(event.data.id, message.id,
+    'event/message.id not equal');
+  assert.equal(event.data.roomId, message.roomId,
+    'event/message.roomId not equal');
+  assert.equal(event.data.personId, message.personId,
+    'event/message.personId not equal');
+  assert.equal(event.data.personEmail, message.personEmail,
+    'event/message.personEmail not equal');
+  assert.equal(event.data.roomType, message.roomType,
+    'event/message.roomType not equal');
   if (event.event === SDK_EVENT.EXTERNAL.EVENT_TYPE.DELETED) {
     return;
   }
-  if (expectedEvent.data.text) {
-    assert.equal(event.data.text, expectedEvent.data.text);
+  if (message.text) {
+    assert.equal(event.data.text, message.text, 'event/message.text not equal');
   }
-  if (expectedEvent.data.files) {
-    assert.isArray(event.data.files);
-    assert.isArray(expectedEvent.data.files);
-    assert.equal(event.data.files.length, expectedEvent.data.files.length);
-    for (let i = 0; i < expectedEvent.data.files.length; i += 1) {
+  if (message.files) {
+    assert.isArray(event.data.files, 'event.data.files is not array');
+    assert.isArray(message.files, 'message.files is not array');
+    assert.equal(event.data.files.length, message.files.length,
+      'event/message file arrays are different lengths');
+    for (let i = 0; i < message.files.length; i += 1) {
       // The gateway returned by the API is apialpha.ciscospark.com
       // The gateway returned in the event is api.ciscospark.com -- expected?
       assert.equal(event.data.files[i].substr(event.data.files[i].lastIndexOf('/') + 1),
-        expectedEvent.data.files[i].substr(expectedEvent.data.files[i].lastIndexOf('/') + 1));
+        message.files[i].substr(message.files[i].lastIndexOf('/') + 1),
+        'event/message file urls do not match');
     }
   }
 }
+

--- a/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
+++ b/packages/node_modules/@webex/plugin-messages/test/integration/spec/messages.js
@@ -253,9 +253,10 @@ describe('plugin-messages', function () {
       describe('#listen()', () => {
         [
           'post',
-          'share'
+          'share',
+          'delete'
         ].forEach((verb) => {
-          it(`emits a "created" event when a "${verb}" activity arrives`, () => {
+          it(`emits an event when a "${verb}" activity arrives`, () => {
             const props = {
               verb
             };
@@ -265,6 +266,7 @@ describe('plugin-messages', function () {
             spark.messages.listen()
               .then(() => {
                 spark.messages.on('created', spy);
+                spark.messages.on('deleted', spy);
                 debug(`create mock activity event: ${JSON.stringify(event)}`);
                 spark.internal.mercury._onmessage(event);
 
@@ -364,7 +366,7 @@ function mockActivityEvent(props) {
 function mockActivity(props) {
   const activity = {
     id: '88888888-4444-4444-4444-000000000001',
-    verb: 'post',
+    verb: props.verb,
     actor: {
       id: '88888888-4444-4444-4444-000000000002',
       entryEmail: 'alice@email.com'

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -101,7 +101,7 @@ const Rooms = SparkPlugin.extend({
 
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
-      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
       if (event === SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED) {
         room = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.OBJECT;
         sdkEvent.data.creatorId =
@@ -295,7 +295,7 @@ const Rooms = SparkPlugin.extend({
    * @returns {Promise<RoomObject>}
    * @example
    * var room;
-   * ciscospark.rooms.create({title: 'Update Room Example'})
+   * ciscospark.rooms.update({title: 'Update Room Example'})
    *   .then(function(r) {
    *     room = r;
    *     room.title = 'Update Room Example (Updated Title)';

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -110,8 +110,10 @@ const Rooms = SparkPlugin.extend({
       }
       else if (event === SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED) {
         room = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
-        // TODO - lastActivity is not in the mercury event
-        // need to determine how to set this in the updated event
+        // TODO - lastActivity is not in the update mercury event
+        // would need to make an async call to get more conversation details
+        // or we can skip this for the SDK, since we will provide an
+        // SDK api to allow the app to query this directly if it needs
         // sdkEvent.data.lastActivity = 'to do';
       }
       else {
@@ -121,8 +123,8 @@ const Rooms = SparkPlugin.extend({
         constructHydraId(hydraTypes.ROOM, activity[room].id);
       sdkEvent.data.type =
         activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
-          SDK_EVENT.FROM_WEBEX.SPACE_TYPE.DIRECT :
-          SDK_EVENT.FROM_WEBEX.SPACE_TYPE.GROUP;
+          SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
+          SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
       sdkEvent.data.isLocked =
         activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.LOCKED);
 

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -38,13 +38,13 @@ const Rooms = SparkPlugin.extend({
    * @returns {Promise}
    */
   listen() {
-    return createEventEnvelope(this.spark, SDK_EVENT.TO_APP.RESOURCE.ROOMS)
+    return createEventEnvelope(this.spark, SDK_EVENT.EXTERNAL.RESOURCE.ROOMS)
       .then((envelope) => {
         this.eventEnvelope = envelope;
 
         return this.spark.internal.mercury.connect().then(() => {
           this.listenTo(this.spark.internal.mercury,
-            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            SDK_EVENT.INTERNAL.TEAMS_ACTIVITY,
             (event) => this.onWebexApiEvent(event));
         });
       });
@@ -60,25 +60,25 @@ const Rooms = SparkPlugin.extend({
 
     /* eslint-disable no-case-declarations */
     switch (activity.verb) {
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.CREATE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.CREATE:
         const roomCreatedEvent =
-          this.getRoomEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
+          this.getRoomEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED);
 
         if (roomCreatedEvent) {
           debug(`room "created" payload: \
             ${JSON.stringify(roomCreatedEvent)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, roomCreatedEvent);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED, roomCreatedEvent);
         }
         break;
 
-      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.UPDATE:
+      case SDK_EVENT.INTERNAL.ACTIVITY_VERB.UPDATE:
         const roomUpdatedEvent =
-          this.getRoomEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED);
+          this.getRoomEvent(activity, SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED);
 
         if (roomUpdatedEvent) {
           debug(`room "updated" payload: \
             ${JSON.stringify(roomUpdatedEvent)}`);
-          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED, roomUpdatedEvent);
+          this.trigger(SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED, roomUpdatedEvent);
         }
         break;
 
@@ -102,14 +102,14 @@ const Rooms = SparkPlugin.extend({
       sdkEvent.event = event;
       sdkEvent.data.created = activity.published;
       sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
-      if (event === SDK_EVENT.TO_APP.EVENT_TYPE.CREATED) {
-        room = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+      if (event === SDK_EVENT.EXTERNAL.EVENT_TYPE.CREATED) {
+        room = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.OBJECT;
         sdkEvent.data.creatorId =
           constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
         sdkEvent.data.lastActivity = activity.published;
       }
-      else if (event === SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED) {
-        room = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+      else if (event === SDK_EVENT.EXTERNAL.EVENT_TYPE.UPDATED) {
+        room = SDK_EVENT.INTERNAL.ACTIVITY_FIELD.TARGET;
         // TODO - lastActivity is not in the update mercury event
         // would need to make an async call to get more conversation details
         // or we can skip this for the SDK, since we will provide an
@@ -122,16 +122,16 @@ const Rooms = SparkPlugin.extend({
       sdkEvent.data.id =
         constructHydraId(hydraTypes.ROOM, activity[room].id);
       sdkEvent.data.type =
-        activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
-          SDK_EVENT.TO_APP.SPACE_TYPE.DIRECT :
-          SDK_EVENT.TO_APP.SPACE_TYPE.GROUP;
+        activity[room].tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.ONE_ON_ONE) ?
+          SDK_EVENT.EXTERNAL.SPACE_TYPE.DIRECT :
+          SDK_EVENT.EXTERNAL.SPACE_TYPE.GROUP;
       sdkEvent.data.isLocked =
-        activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.LOCKED);
+        activity[room].tags.includes(SDK_EVENT.INTERNAL.ACTIVITY_TAG.LOCKED);
 
       return sdkEvent;
     }
     catch (e) {
-      console.error(`Unable to generate SDK event from mercury \
+      this.spark.logger.error(`Unable to generate SDK event from mercury \
 'socket activity for rooms:${event} event: ${e.message}`);
 
       return null;

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -2,7 +2,16 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {SparkPlugin, Page} from '@webex/webex-core';
+import {SparkPlugin, Page} from '@ciscospark/spark-core';
+import {cloneDeep} from 'lodash';
+import {
+  SDK_EVENT,
+  createEventEnvelope,
+  hydraTypes,
+  constructHydraId
+} from '@ciscospark/common';
+
+const debug = require('debug')('memberships');
 
 /**
  * @typedef {Object} RoomObject
@@ -24,6 +33,109 @@ import {SparkPlugin, Page} from '@webex/webex-core';
  * @name Rooms
  */
 const Rooms = SparkPlugin.extend({
+  /**
+   * Connect to the web socket to listen to incoming messages.
+   * @returns {Promise}
+   */
+  listen() {
+    return createEventEnvelope(this.spark, SDK_EVENT.TO_APP.RESOURCE.ROOMS)
+      .then((envelope) => {
+        this.eventEnvelope = envelope;
+
+        return this.spark.internal.mercury.connect().then(() => {
+          this.listenTo(this.spark.internal.mercury,
+            SDK_EVENT.FROM_WEBEX.TEAMS_ACTIVITY,
+            (event) => this.onWebexApiEvent(event));
+        });
+      });
+  },
+
+  /**
+   * Trigger a membership related events.
+   * @param {Object} event
+   * @returns {undefined} -- nothing //linter requires return in JSDoc
+   */
+  onWebexApiEvent(event) {
+    const {activity} = event.data;
+
+    /* eslint-disable no-case-declarations */
+    switch (activity.verb) {
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.CREATE:
+        const roomCreatedEvent =
+          this.getRoomEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.CREATED);
+
+        if (roomCreatedEvent) {
+          debug(`room "created" payload: \
+            ${JSON.stringify(roomCreatedEvent)}`);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.CREATED, roomCreatedEvent);
+        }
+        break;
+
+      case SDK_EVENT.FROM_WEBEX.ACTIVITY_VERB.UPDATE:
+        const roomUpdatedEvent =
+          this.getRoomEvent(activity, SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED);
+
+        if (roomUpdatedEvent) {
+          debug(`room "updated" payload: \
+            ${JSON.stringify(roomUpdatedEvent)}`);
+          this.trigger(SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED, roomUpdatedEvent);
+        }
+        break;
+
+      default:
+        break;
+    }
+  },
+
+  /**
+   * Constructs the data object for an event on the rooms resource,
+   * adhering to Hydra's Webehook data structure.
+   * @param {Object} activity from mercury
+   * @param {Object} event type of "webhook" event
+   * @returns {Object} constructed event
+   */
+  getRoomEvent(activity, event) {
+    try {
+      const sdkEvent = cloneDeep(this.eventEnvelope);
+      let room;
+
+      sdkEvent.event = event;
+      sdkEvent.data.created = activity.published;
+      sdkEvent.actorId = constructHydraId(hydraTypes.PEOPLE, activity.actor.id);
+      if (event === SDK_EVENT.TO_APP.EVENT_TYPE.CREATED) {
+        room = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.OBJECT;
+        sdkEvent.data.creatorId =
+          constructHydraId(hydraTypes.PEOPLE, activity.actor.entryUUID);
+        sdkEvent.data.lastActivity = activity.published;
+      }
+      else if (event === SDK_EVENT.TO_APP.EVENT_TYPE.UPDATED) {
+        room = SDK_EVENT.FROM_WEBEX.ACTIVITY_FIELD.TARGET;
+        // TODO - lastActivity is not in the mercury event
+        // need to determine how to set this in the updated event
+        // sdkEvent.data.lastActivity = 'to do';
+      }
+      else {
+        throw new Error('unexpected event type');
+      }
+      sdkEvent.data.id =
+        constructHydraId(hydraTypes.ROOM, activity[room].id);
+      sdkEvent.data.type =
+        activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.ONE_ON_ONE) ?
+          SDK_EVENT.FROM_WEBEX.SPACE_TYPE.DIRECT :
+          SDK_EVENT.FROM_WEBEX.SPACE_TYPE.GROUP;
+      sdkEvent.data.isLocked =
+        activity[room].tags.includes(SDK_EVENT.FROM_WEBEX.ACTIVITY_TAG.LOCKED);
+
+      return sdkEvent;
+    }
+    catch (e) {
+      console.error(`Unable to generate SDK event from mercury \
+'socket activity for rooms:${event} event: ${e.message}`);
+
+      return null;
+    }
+  },
+
   /**
    * Creates a new room. The authenticated user is automatically added as a
    * member of the room. See the {@link Memberships} API to learn how to add

--- a/packages/node_modules/@webex/plugin-rooms/src/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/src/rooms.js
@@ -2,14 +2,14 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import {SparkPlugin, Page} from '@ciscospark/spark-core';
+import {SparkPlugin, Page} from '@webex/webex-core';
 import {cloneDeep} from 'lodash';
 import {
   SDK_EVENT,
   createEventEnvelope,
   hydraTypes,
   constructHydraId
-} from '@ciscospark/common';
+} from '@webex/common';
 
 const debug = require('debug')('memberships');
 

--- a/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
@@ -2,43 +2,119 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@webex/internal-plugin-wdm';
-import '@webex/plugin-logger';
-import '@webex/plugin-rooms';
-import CiscoSpark, {SparkHttpError} from '@webex/webex-core';
-import {assert} from '@webex/test-helper-chai';
-import sinon from '@webex/test-helper-sinon';
-import testUsers from '@webex/test-helper-test-users';
+import '@ciscospark/internal-plugin-wdm';
+import '@ciscospark/internal-plugin-mercury';
+import '@ciscospark/plugin-logger';
+import '@ciscospark/plugin-people';
+import '@ciscospark/plugin-rooms';
+import '@ciscospark/plugin-messages';
+import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
+import {
+  SDK_EVENT,
+  hydraTypes,
+  constructHydraId
+} from '@ciscospark/common';
+import {assert} from '@ciscospark/test-helper-chai';
+import sinon from '@ciscospark/test-helper-sinon';
+import testUsers from '@ciscospark/test-helper-test-users';
+
+const debug = require('debug')('rooms');
 
 describe('plugin-rooms', function () {
   this.timeout(60000);
 
-  let spark;
+  let spark, actor;
 
   before(() => testUsers.create({count: 1})
     .then(([user]) => {
       spark = new CiscoSpark({credentials: user.token});
+      spark.people.get('me')
+        .then((person) => {
+          actor = person;
+          debug('SDK User (Actor) for tests:');
+          debug(`- name: ${actor.displayName}`);
+          debug(`-   id: ${actor.id}`);
+        });
     }));
 
   describe('#rooms', () => {
     const rooms = [];
 
-    afterEach(() => Promise.all(rooms.map((room) => spark.rooms.remove(room)
-      .catch((reason) => {
-        console.error('Failed to delete room', reason);
-      })))
-      .then(() => {
-        while (rooms.length) {
-          rooms.pop();
-        }
-      }));
+    afterEach(() => {
+      spark.rooms.stopListening();
+
+      return Promise.all(rooms.map((room) => spark.rooms.remove(room)
+        .catch((reason) => {
+          console.error('Failed to delete room', reason);
+        })))
+        .then(() => {
+          while (rooms.length) {
+            rooms.pop();
+          }
+        });
+    });
 
     describe('#create()', () => {
-      it('creates a room', () => spark.rooms.create({title: 'Cisco Spark Test Room'})
-        .then((room) => {
-          rooms.push(room);
-          assert.isRoom(room);
+      it('creates a room and validates the room:created event', () => {
+        const createdEventPromise = new Promise((resolve) => {
+          spark.rooms.on('created', (event) => {
+            debug('room:created event handler called');
+            resolve(event);
+          });
+        });
+
+        return spark.rooms.listen()
+          .then(() => spark.rooms.create({title: 'Cisco Spark Test Room'})
+            .then(async (room) => {
+              assert.isRoom(room);
+              rooms.push(room); // for future cleanup
+              const event = await createdEventPromise;
+
+              validateRoomEvent(event, room, actor);
+            }));
+      });
+    });
+
+    describe('#one-on-one()', () => {
+      let user1, room;
+
+      before(() => testUsers.create({count: 1})
+        .then((users) => {
+          user1 = users[0];
+          debug('Test User for One-on-One room:');
+          debug(`- name: ${user1.displayName}`);
+          debug(`-   id: ${constructHydraId(hydraTypes.PEOPLE, user1.id)}`);
         }));
+
+      // We need a one-on-on space for this test
+      // We create it by sending a message to the test user
+      it('creates a 1-1 space and validates the room type', () => {
+        const createdEventPromise = new Promise((resolve) => {
+          spark.rooms.on('created', (event) => {
+            debug('room:created event handler called');
+            debug(event);
+            resolve(event);
+          });
+        });
+
+        return spark.rooms.listen()
+          .then(() => spark.messages.create({
+            toPersonId: user1.id,
+            text: 'Message to start a one-on-on space'
+          })
+            .then((message) => {
+              assert.exists(message.roomId);
+
+              return spark.rooms.get({id: message.roomId});
+            })
+            .then(async (r) => {
+              room = r;
+              assert.isRoom(room);
+              const event = await createdEventPromise;
+
+              validateRoomEvent(event, room, actor);
+            }));
+      });
     });
 
     describe('#get()', () => {
@@ -130,14 +206,24 @@ describe('plugin-rooms', function () {
           assert.property(room, 'id');
         }));
 
-      it('updates a single room\'s title', () => {
+      it('updates a single room\'s title and validates a room:updated event', () => {
         const r = Object.assign({}, room, {title: 'Cisco Spark Test Room with New Title'});
-
-        spark.rooms.update(r)
-          .then((room) => {
-            assert.isRoom(room);
-            assert.deepEqual(room, r);
+        const updatedEventPromise = new Promise((resolve) => {
+          spark.rooms.on('updated', (event) => {
+            debug('room:updated event handler called');
+            resolve(event);
           });
+        });
+
+        return spark.rooms.listen()
+          .then(() => spark.rooms.update(r)
+            .then(async (room) => {
+              assert.isRoom(room);
+              assert.deepEqual(room, r);
+              const event = await updatedEventPromise;
+
+              validateRoomEvent(event, room, actor);
+            }));
       });
     });
 
@@ -162,3 +248,34 @@ describe('plugin-rooms', function () {
     });
   });
 });
+
+/**
+ * Validate a rooms event.
+ * @param {Object} event - rooms event
+ * @param {Object} room -- return from the API that generated this event
+ * @param {Object} actor - person object for user who performed action
+ * @returns {void}
+ */
+function validateRoomEvent(event, room, actor) {
+  assert.isTrue(event.resource === SDK_EVENT.EXTERNAL.RESOURCE.ROOMS,
+    'not a room event');
+  assert.isDefined(event.event, 'room event type not set');
+  assert.isDefined(event.created, 'event listener created date not set');
+  assert.equal(event.createdBy, actor.id,
+    'event listener createdBy not set to our actor');
+  assert.equal(event.orgId, actor.orgId,
+    'event listener orgId not === to our actor\'s');
+  assert.equal(event.ownedBy, 'creator', 'event listener not owned by creator');
+  assert.equal(event.status, 'active', 'event listener status not active');
+  assert.equal(event.actorId, actor.id,
+    'event actorId not equal to our actor\'s id');
+
+  // Ensure event data matches data returned from function call
+  // Skip this until we figure out how conversations converts the internal test user UUID
+  assert.equal(event.data.id, room.id,
+    'event/room.id not equal');
+  assert.equal(event.data.isLocked, room.isLocked,
+    'event/room.isLocked not equal');
+  assert.equal(event.data.type, room.type,
+    'event/room.type not equal');
+}

--- a/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
+++ b/packages/node_modules/@webex/plugin-rooms/test/integration/spec/rooms.js
@@ -2,21 +2,21 @@
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
 
-import '@ciscospark/internal-plugin-wdm';
-import '@ciscospark/internal-plugin-mercury';
-import '@ciscospark/plugin-logger';
-import '@ciscospark/plugin-people';
-import '@ciscospark/plugin-rooms';
-import '@ciscospark/plugin-messages';
-import CiscoSpark, {SparkHttpError} from '@ciscospark/spark-core';
+import '@webex/internal-plugin-wdm';
+import '@webex/internal-plugin-mercury';
+import '@webex/plugin-logger';
+import '@webex/plugin-people';
+import '@webex/plugin-rooms';
+import '@webex/plugin-messages';
+import CiscoSpark, {SparkHttpError} from '@webex/webex-core';
 import {
   SDK_EVENT,
   hydraTypes,
   constructHydraId
-} from '@ciscospark/common';
-import {assert} from '@ciscospark/test-helper-chai';
-import sinon from '@ciscospark/test-helper-sinon';
-import testUsers from '@ciscospark/test-helper-test-users';
+} from '@webex/common';
+import {assert} from '@webex/test-helper-chai';
+import sinon from '@webex/test-helper-sinon';
+import testUsers from '@webex/test-helper-test-users';
 
 const debug = require('debug')('rooms');
 

--- a/packages/node_modules/samples/browser-socket/app.js
+++ b/packages/node_modules/samples/browser-socket/app.js
@@ -75,6 +75,10 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
             console.log('message created event:');
             console.log(message);
           });
+          webex.messages.on('deleted', (message) => {
+            console.log('message deleted event:');
+            console.log(message);
+          });
         })
         .catch((err) => {
           console.error(`error listening to messages: ${err}`);

--- a/packages/node_modules/samples/browser-socket/app.js
+++ b/packages/node_modules/samples/browser-socket/app.js
@@ -84,6 +84,7 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
           console.error(`error listening to messages: ${err}`);
           updateStatus(false);
         });
+
       webex.memberships.listen()
         .then(() => {
           console.log('listening to membership events');
@@ -106,7 +107,25 @@ document.getElementById('credentials').addEventListener('submit', (event) => {
           });
         })
         .catch((err) => {
-          console.error(`error listening to messages: ${err}`);
+          console.error(`error listening to memberships: ${err}`);
+          updateStatus(false);
+        });
+
+      webex.rooms.listen()
+        .then(() => {
+          console.log('listening to room events');
+          updateStatus(true);
+          webex.rooms.on('created', (room) => {
+            console.log('room created event');
+            console.log(room);
+          });
+          webex.rooms.on('updated', (room) => {
+            console.log('room updated event');
+            console.log(room);
+          });
+        })
+        .catch((err) => {
+          console.error(`error listening to rooms: ${err}`);
           updateStatus(false);
         });
     })

--- a/packages/node_modules/samples/browser-socket/index.html
+++ b/packages/node_modules/samples/browser-socket/index.html
@@ -28,8 +28,22 @@
 
           <p>Open this browser's <em>inspection tools</em> to view the <em>console</em>.</p>
           <p>
-            Open <a href="spark://">Webex Teams</a> and type a message to someone.
-            The messages' <em>created</em> event will fire and display the message in the console.
+            Open <a href="https://teams.webex.com/teams/">Webex Teams</a> and create rooms, memberships or messages.  
+            These activities will generate an event which will fire and display in the console.<br><br>
+
+            See the Webex <a href="https://developer.webex.com/docs/api/guides/webhooks/filtering-webhooks">Webhook Documentation</a> 
+            for more information on the payloads of the membership, message and room events.   In general
+            the SDK events closely match the payload of the webhooks, except in cases where the information
+            in a traditional webhook envelope doesn't make sense, for example there is no <em>name, targetUrl</em>, or 
+            <em>secret</em> field in the SDK event envelopes.<br><br>
+
+            The SDK adds one event which is not yet supported in the webhooks.  A <em>memberships:seen</em> event 
+            is generated when a Webex client sends a "read receipt".   The <em>membership:seen</em> event will include a 
+            <em>lastSeenId</em> field with the id of the last message read by the user.<br><br>
+
+            View the <a href="https://github.com/webex/spark-js-sdk/blob/master/packages/node_modules/samples/browser-socket/app.js">
+            source for this app</a>
+
           </p>
         </div>
       </div>

--- a/packages/node_modules/samples/browser-socket/index.html
+++ b/packages/node_modules/samples/browser-socket/index.html
@@ -29,21 +29,23 @@
           <p>Open this browser's <em>inspection tools</em> to view the <em>console</em>.</p>
           <p>
             Open <a href="https://teams.webex.com/teams/">Webex Teams</a> and create rooms, memberships or messages.  
-            These activities will generate an event which will fire and display in the console.<br><br>
-
+            These activities will generate an event which will fire and display in the console.
+          </p>
+          <p>
             See the Webex <a href="https://developer.webex.com/docs/api/guides/webhooks/filtering-webhooks">Webhook Documentation</a> 
             for more information on the payloads of the membership, message and room events.   In general
             the SDK events closely match the payload of the webhooks, except in cases where the information
             in a traditional webhook envelope doesn't make sense, for example there is no <em>name, targetUrl</em>, or 
-            <em>secret</em> field in the SDK event envelopes.<br><br>
-
+            <em>secret</em> field in the SDK event envelopes.
+          </p>
+          <p>
             The SDK adds one event which is not yet supported in the webhooks.  A <em>memberships:seen</em> event 
             is generated when a Webex client sends a "read receipt".   The <em>membership:seen</em> event will include a 
-            <em>lastSeenId</em> field with the id of the last message read by the user.<br><br>
-
+            <em>lastSeenId</em> field with the id of the last message read by the user.
+          </p>
+          <p>
             View the <a href="https://github.com/webex/spark-js-sdk/blob/master/packages/node_modules/samples/browser-socket/app.js">
             source for this app</a>
-
           </p>
         </div>
       </div>


### PR DESCRIPTION
# Pull Request Template

## Description

Add ability to send events for room objects.   Based on previous feedback, move all event based constants into a single object.  Also add a common function for creating event envelopes.  Update messages and memberships event code to use new constant object and envelope function.

This PR is based on https://github.com/webex/spark-js-sdk/pull/1145

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Test Coverage

Register a webhook for rooms for a user to a location where you can easily examine the message payloads (ie: https://pipedream.com)
Navigate to https://localhost:8000/browser-socket. Initialize with the token of the user who registered the webhooks

WIth that test user create a new room. Compare the payload of the rooms:create webhook with the payload of the rooms:create event, which is printed in the browser console. Repeat for renaming the room and examining the rooms:updated webhook and event.

**Test Configuration**:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -- requires approved PR https://github.com/webex/spark-js-sdk/pull/1145 to be merged
