### PR TITLE
feat(wdm): add people insights admin toggle to device

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/src/device/device.js
@@ -75,6 +75,7 @@ const Device = SparkPlugin.extend({
     modificationTime: 'string',
     partnerCompanyName: 'string',
     partnerLogoUrl: 'string',
+    peopleInsightsEnabled: 'boolean',
     reportingSiteDesc: 'string',
     reportingSiteUrl: 'string',
     searchEncryptionKeyUrl: 'string',

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/integration/spec/device.js
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/integration/spec/device.js
@@ -30,6 +30,7 @@ describe('plugin-wdm', function () {
           assert.property(spark.internal.device, 'helpUrl');
           assert.property(spark.internal.device, 'partnerCompanyName');
           assert.property(spark.internal.device, 'partnerLogoUrl');
+          assert.property(spark.internal.device, 'peopleInsightsEnabled');
           assert.property(spark.internal.device, 'reportingSiteDesc');
           assert.property(spark.internal.device, 'reportingSiteUrl');
           assert.property(spark.internal.device, 'showSupportText');

--- a/packages/node_modules/@webex/internal-plugin-wdm/test/unit/lib/device-fixture.json
+++ b/packages/node_modules/@webex/internal-plugin-wdm/test/unit/lib/device-fixture.json
@@ -108,6 +108,7 @@
   "helpUrl": "www.example.com/help",
   "partnerCompanyName": "Example Partners",
   "partnerLogoUrl": "www.example.com/partner-logo",
+  "peopleInsightsEnabled": false,
   "reportingSiteDesc": "Example Description",
   "reportingSiteUrl": "www.example.com/report",
   "showSupportText": false,


### PR DESCRIPTION
# Pull Request Template

## Description

There will be a new peopleInsightsEnabled toggle from control hub and we want to be able to read the value

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
