### PR TITLE
fix(ediscovery): adding bulk support for emails to uuid conversion

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
@@ -2,7 +2,7 @@
 /*!
  * Copyright (c) 2015-2017 Cisco Systems, Inc. See LICENSE file.
  */
-
+import {InvalidEmailAddressError} from './ediscovery-error';
 import {waitForValue, SparkPlugin} from '@webex/webex-core';
 import {oneFlight} from '@webex/common';
 
@@ -219,6 +219,94 @@ const EDiscovery = SparkPlugin.extend({
       resource: `reports/${reportId}/contents/summary/${spaceId}`
     })
       .then((res) => res.body);
+  },
+
+  @waitForValue('@')
+  /**
+   * Converts an array of email addresses to their corresponding user ids in CI
+   * @param {Array<String>} emails - Array of email addresses
+   * @returns {Array<UUID>} User ids for the email addresses being requested
+   */
+  convertEmailsToUserIds(emails) {
+    const userIds = [];
+
+    if (!emails || emails.length <= 0) {
+      return userIds;
+    }
+
+    if (emails.length > 500) {
+      throw Error('The maximum number of emails that can be converted is 500');
+    }
+
+    let orgId = '';
+
+    // find the org id for the compliance officer, as this is required for the SCIM request
+    return this.spark.people.get('me')
+      .then((res) => {
+        // Org id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU
+        const decodedOrgId = Buffer.from(res.orgId, 'base64').toString();
+
+        // Decode and strip out the uuid
+        orgId = decodedOrgId.substring(decodedOrgId.lastIndexOf('/') + 1, decodedOrgId.length);
+      })
+      .then(() => {
+        if (!orgId) {
+          throw Error('Cannot find org id for user');
+        }
+
+        const promises = [];
+        const maxFilterEmails = 50;
+        const validUserNames = [];
+
+        // the hydra SCIM request can have a maximum of 50 filter arguments, so we may have to make multiple requests
+        for (let i = 0; i < emails.length; i += maxFilterEmails) {
+          // build query filter containing no more than 50 emails
+          const emailBatch = emails.slice(i, i + maxFilterEmails);
+          let filter = '';
+
+          for (const email of emailBatch) {
+            filter += `userName eq "${email}" or `;
+          }
+          // remove trailing ' or '
+          filter = filter.slice(0, -4);
+
+          // certain characters must first be encoded for the request to work successfully
+          filter = encodeURIComponent(filter);
+
+          const promise = this.request({
+            method: 'GET',
+            service: 'hydra',
+            resource: `scim/${orgId}/Users?filter=${filter}`
+          })
+            .then((res) => {
+              for (const resource of res.body.Resources) {
+                // User id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU
+                const decodedUserId = Buffer.from(resource.id, 'base64').toString();
+
+                // Decode and strip out the uuid ciscospark://us/PEOPLE/5d59b795-6fa2-4654-8ec2-769db15c0d9e
+                userIds.push(decodedUserId.substring(decodedUserId.lastIndexOf('/') + 1, decodedUserId.length));
+
+                // compile a list of usernames that were successfully converted to uuids
+                // we will cross check this with the original list of emails to ensure no errors occurred
+                validUserNames.push(resource.userName);
+              }
+            });
+
+          promises.push(promise);
+        }
+
+        return Promise.all(promises)
+          .then(() => {
+            if (emails.length !== validUserNames.length) {
+              // if user ids could not be found for any emails we assume they were invalid and throw a custom error
+              const invalidEmails = emails.filter((email) => !validUserNames.includes(email));
+
+              return Promise.reject(new InvalidEmailAddressError(invalidEmails));
+            }
+
+            return userIds;
+          });
+      });
   }
 
 });

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/ediscovery.js
@@ -4,7 +4,7 @@
  */
 import {InvalidEmailAddressError} from './ediscovery-error';
 import {waitForValue, SparkPlugin} from '@webex/webex-core';
-import {oneFlight} from '@webex/common';
+import {oneFlight, base64} from '@webex/common';
 
 import Map from 'babel-runtime/core-js/map';
 
@@ -244,9 +244,9 @@ const EDiscovery = SparkPlugin.extend({
     return this.spark.people.get('me')
       .then((res) => {
         // Org id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU
-        const decodedOrgId = Buffer.from(res.orgId, 'base64').toString();
+        const decodedOrgId = base64.decode(res.orgId);
 
-        // Decode and strip out the uuid
+        // Decode and strip out the uuid ciscospark://us/ORGANIZATION/8ceb2dbf-7a2c-41bf-91bb-a42a37d69b74
         orgId = decodedOrgId.substring(decodedOrgId.lastIndexOf('/') + 1, decodedOrgId.length);
       })
       .then(() => {
@@ -281,7 +281,7 @@ const EDiscovery = SparkPlugin.extend({
             .then((res) => {
               for (const resource of res.body.Resources) {
                 // User id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU
-                const decodedUserId = Buffer.from(resource.id, 'base64').toString();
+                const decodedUserId = base64.decode(resource.id);
 
                 // Decode and strip out the uuid ciscospark://us/PEOPLE/5d59b795-6fa2-4654-8ec2-769db15c0d9e
                 userIds.push(decodedUserId.substring(decodedUserId.lastIndexOf('/') + 1, decodedUserId.length));

--- a/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
+++ b/packages/node_modules/@webex/internal-plugin-ediscovery/src/index.js
@@ -9,7 +9,6 @@ import {registerInternalPlugin} from '@webex/webex-core';
 import {has} from 'lodash';
 
 import EDiscovery from './ediscovery';
-import {InvalidEmailAddressError} from './ediscovery-error';
 
 registerInternalPlugin('ediscovery', EDiscovery, {
   payloadTransformer: {
@@ -104,12 +103,26 @@ registerInternalPlugin('ediscovery', EDiscovery, {
             return Promise.resolve();
           }
           const {reportRequest} = object.body;
+
+          const reportNamePromise = ctx.transform('decryptTextProp', 'name', reportRequest.encryptionKeyUrl, reportRequest)
+            .catch((reason) => {
+              ctx.spark.logger.error(`Error decrypting report name for report ${object.body.id}: ${reason}`);
+            });
+
+          const reportDescriptionPromise = ctx.transform('decryptTextProp', 'description', reportRequest.encryptionKeyUrl, reportRequest)
+            .catch((reason) => {
+              ctx.spark.logger.error(`Error decrypting description for report ${object.body.id}: ${reason}`);
+            });
+
           let spaceNamePromises = [];
 
           if (reportRequest.spaceNames) {
             spaceNamePromises = Promise.all(reportRequest.spaceNames.map((spaceName) => ctx.spark.internal.encryption.decryptText(reportRequest.encryptionKeyUrl, spaceName)))
               .then((decryptedSpaceNames) => {
                 reportRequest.spaceNames = decryptedSpaceNames;
+              })
+              .catch((reason) => {
+                ctx.spark.logger.error(`Error decrypting space name for report ${object.body.id}: ${reason}`);
               });
           }
 
@@ -119,6 +132,9 @@ registerInternalPlugin('ediscovery', EDiscovery, {
             keywordPromises = Promise.all(reportRequest.keywords.map((keyword) => ctx.spark.internal.encryption.decryptText(reportRequest.encryptionKeyUrl, keyword)))
               .then((decryptedKeywords) => {
                 reportRequest.keywords = decryptedKeywords;
+              })
+              .catch((reason) => {
+                ctx.spark.logger.error(`Error decrypting keywords for report ${object.body.id}: ${reason}`);
               });
           }
 
@@ -128,13 +144,13 @@ registerInternalPlugin('ediscovery', EDiscovery, {
             emailPromises = Promise.all(reportRequest.emails.map((email) => ctx.spark.internal.encryption.decryptText(reportRequest.encryptionKeyUrl, email)))
               .then((decryptedEmails) => {
                 reportRequest.emails = decryptedEmails;
+              })
+              .catch((reason) => {
+                ctx.spark.logger.error(`Error decrypting emails for report ${object.body.id}: ${reason}`);
               });
           }
 
-          return Promise.all([
-            ctx.transform('decryptTextProp', 'name', reportRequest.encryptionKeyUrl, reportRequest),
-            ctx.transform('decryptTextProp', 'description', reportRequest.encryptionKeyUrl, reportRequest)
-          ].concat(spaceNamePromises, keywordPromises, emailPromises));
+          return Promise.all([reportNamePromise, reportDescriptionPromise].concat(spaceNamePromises, keywordPromises, emailPromises));
         }
       },
       {
@@ -155,44 +171,15 @@ registerInternalPlugin('ediscovery', EDiscovery, {
           if (!object || !object.body || !object.body.emails || object.body.emails.length <= 0) {
             return Promise.resolve();
           }
-          const reportRequest = object.body;
 
-          const promises = [];
-          const invalidEmails = [];
+          return ctx.spark.internal.ediscovery.convertEmailsToUserIds(object.body.emails)
+            .then((userIds) => {
+              object.body.userIds = userIds;
+            })
+            .catch((reason) => {
+              ctx.spark.logger.error(`Error while converting emails to uuids: ${reason}`);
 
-          reportRequest.emails.forEach((userEmail) => {
-            promises.push(
-              // The people list API only supports a single email
-              ctx.spark.people.list({email: userEmail})
-                .then((res) => {
-                  let uuid = '';
-
-                  if (res.items.length <= 0) {
-                    ctx.spark.logger.error(`Unable to find user with email ${userEmail}`);
-                    invalidEmails.push(userEmail);
-                  }
-                  else {
-                    // User id is base64 encoded and of the format Y2lzY29zcGFyazovL3VzL1BFT1BMRS81ZDU5Yjc5NS02ZmEyLTQ2NTQtOGVjMi03NjlkYjE1YzBkOWU
-                    const decodedId = Buffer.from(res.items[0].id, 'base64').toString();
-
-                    // Decode and strip out the uuid ciscospark://us/PEOPLE/5d59b795-6fa2-4654-8ec2-769db15c0d9e
-                    uuid = decodedId.substring(decodedId.lastIndexOf('/') + 1, decodedId.length);
-                  }
-
-                  return uuid;
-                })
-                .catch((reason) => Promise.reject(reason))
-            );
-          });
-
-          return Promise.all(promises)
-            .then((uuids) => {
-              if (invalidEmails.length) {
-                return Promise.reject(new InvalidEmailAddressError(invalidEmails));
-              }
-              reportRequest.userIds = uuids;
-
-              return Promise.resolve();
+              return Promise.reject(reason);
             });
         }
       },
@@ -250,7 +237,11 @@ registerInternalPlugin('ediscovery', EDiscovery, {
 
               return Promise.resolve();
             })
-            .catch((reason) => Promise.reject(reason));
+            .catch((reason) => {
+              ctx.spark.logger.error(`Error while encrypting report request: ${reportRequest} : ${reason}`);
+
+              return Promise.reject(reason);
+            });
         }
       },
       {
@@ -308,8 +299,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                   })
                   .catch((reason) => {
                     ctx.spark.logger.error(`Decrypt message error for activity ${activity.activityId}: ${reason}`);
+                    // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                    activity.error = reason;
 
-                    return object; // TODO - determine correct behaviour when an individual operation fails
+                    return object;
                   }));
               }
 
@@ -333,8 +326,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                       })
                       .catch((reason) => {
                         ctx.spark.logger.error(`Decrypt DisplayName error for activity ${activity.activityId} and share ${share}: ${reason}`);
+                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                        activity.error = reason;
 
-                        return object; // TODO - determine correct behaviour when an individual operation fails
+                        return object;
                       })
                   );
                 }
@@ -349,8 +344,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                         })
                         .catch((reason) => {
                           ctx.spark.logger.error(`Decrypt share.microsoftSharedLinkInfo.driveId error for activity ${activity.activityId} and share ${share}: ${reason}`);
+                          // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                          activity.error = reason;
 
-                          return object; // TODO - determine correct behaviour when an individual operation fails
+                          return object;
                         })
                     );
                   }
@@ -363,8 +360,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                         })
                         .catch((reason) => {
                           ctx.spark.logger.error(`Decrypt share.microsoftSharedLinkInfo.itemId error for activity ${activity.activityId} and share ${share}: ${reason}`);
+                          // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                          activity.error = reason;
 
-                          return object; // TODO - determine correct behaviour when an individual operation fails
+                          return object;
                         })
                     );
                   }
@@ -386,8 +385,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
                       })
                       .catch((reason) => {
                         ctx.spark.logger.error(`Decrypt file scr or sslr error for activity ${activity.activityId} and share ${share}: ${reason}`);
+                        // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+                        activity.error = reason;
 
-                        return object; // TODO - determine correct behaviour when an individual operation fails
+                        return object;
                       })
                   );
                 }
@@ -397,6 +398,8 @@ registerInternalPlugin('ediscovery', EDiscovery, {
             })
             .catch((reason) => {
               ctx.spark.logger.error(`Error retrieving space summary for: ${object.activityId}: ${reason}`);
+              // add error property to activity - this error will be recorded in the downloader and the activity omitted from the report
+              activity.error = reason;
 
               return object;
             });
@@ -431,8 +434,10 @@ registerInternalPlugin('ediscovery', EDiscovery, {
             })
             .catch((reason) => {
               ctx.spark.logger.error(`Decrypt space name error for space ${spaceSummary.spaceId}: ${reason}`);
+              // add error property to space info - this error will be recorded in the downloader
+              spaceSummary.error = reason;
 
-              return object; // TODO - determine correct behaviour when an individual operation fails
+              return object;
             });
         }
       },


### PR DESCRIPTION
## Description
Previously, when we needed to convert an email address to a user id we called an API in the People plugin for each email we required. For large amounts of emails (the client currently allows up to 500 emails as parameters in each report), this resulted in many requests and some of those requests were rate-limited and received 429 responses. This fix switches over to a SCIM api in hydra which allows batching of emails in a single request. It can process 50 emails in a single request, so we may still have to make multiple requests, but not on a scale which we expect to cause issues.

Also making changes to the way some errors are logged/reported during some flows in the plugin.

## Fixes
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-72848

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Coverage

This scenario is currently only covered by test scripts that are run in the load test environment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules