### PR TITLE
chore: open head(full?) browsers in debug mode

### DIFF
--- a/browsers-ng.js
+++ b/browsers-ng.js
@@ -78,6 +78,12 @@ module.exports = function(packageName, argv) {
       }
     }
   }
+  else if (argv.karmaDebug) {
+    browsers = {
+      Chrome: {},
+      Firefox: {}
+    };
+  }
   else {
     browsers = {
       ChromeHeadless: {},


### PR DESCRIPTION
The `--karma-debug` helper flag is useless in headless mode. 