### PR TITLE
fix(internal-conversation-plugin): parent reserved word issue

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -468,7 +468,15 @@ const Conversation = SparkPlugin.extend({
           objectType: 'activity',
           clientTempId: uuid.v4(),
           actor: this.spark.internal.device.userId
-        }, pick(activity, 'activityType', 'parentActivityId', 'parent'));
+        });
+
+        // Workaround because parent is a reserved props in Ampersand
+        if ((activity.parentActivityId && activity.activityType) || (activity.parent && activity.parent.id && activity.parent.type)) {
+          act.parent = {
+            id: activity.parentActivityId || activity.parent.id,
+            type: activity.activityType || activity.parent.type
+          };
+        }
 
         if (isString(act.actor)) {
           act.actor = {


### PR DESCRIPTION
## Description
`parent` is a reserved props in Ampersand.
Replacing `parent` props of share activity objects in client side causes issues.
Thus if it is a thread reply, then construct `parent` property just before posting it to the server.

## Type of Change
Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
