### PR TITLE
refactor(internal-plugin-conversation): send parentActivity

### DIFF
--- a/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/src/conversation.js
@@ -3,15 +3,17 @@
  */
 
 import querystring from 'querystring';
+import {EventEmitter} from 'events';
+
 import {proxyEvents, tap} from '@webex/common';
 import {SparkPlugin} from '@webex/webex-core';
 import {cloneDeep, defaults, isArray, isObject, isString, last, map, merge, omit, pick, uniq} from 'lodash';
 import {readExifData} from '@webex/helper-image';
 import uuid from 'uuid';
+
 import {InvalidUserCreation} from './convo-error';
 import ShareActivity from './share-activity';
 
-import {EventEmitter} from 'events';
 
 const Conversation = SparkPlugin.extend({
   namespace: 'Conversation',
@@ -407,7 +409,12 @@ const Conversation = SparkPlugin.extend({
     }, activity);
   },
 
-  cardAction(conversation, inputs, activity) {
+  cardAction(conversation, inputs, parentActivity, activity = {}) {
+    activity.parent = {
+      id: parentActivity.id,
+      type: 'cardAction'
+    };
+
     return this._inferConversationUrl(conversation)
       .then(() => this.prepare(activity, {
         verb: 'cardAction',

--- a/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/encryption.js
+++ b/packages/node_modules/@webex/internal-plugin-conversation/test/integration/spec/encryption.js
@@ -144,15 +144,21 @@ describe('plugin-conversation', () => {
       });
 
       describe('#cardAction()', () => {
-        it('creates a cardAction Activity', () => spark.internal.conversation.cardAction(conversation, {
-          objectType: 'submit',
-          inputs: {key: 'value'}
-        })
+        it('creates a cardAction Activity', () => spark.internal.conversation.post(conversation, {displayName: 'First Message', cards: ['test']})
           .then(() => checkov.spark.internal.conversation.get(conversation, {activitiesLimit: 1}))
           .then((c) => {
             assert.property(c, 'defaultActivityEncryptionKeyUrl');
-            /* eslint-disable no-unused-expressions */
-            expect(c.activities.items[0].object.inputs).to.not.be.null;
+            assert.equal(c.activities.items[0].object.displayName, 'First Message');
+            spark.internal.conversation.cardAction(conversation, {
+              objectType: 'submit',
+              inputs: {key: 'value'}
+            }, c.activities.items[0])
+              .then(() => checkov.spark.internal.conversation.get(conversation, {activitiesLimit: 1}))
+              .then((ci) => {
+                assert.property(c, 'defaultActivityEncryptionKeyUrl');
+                /* eslint-disable no-unused-expressions */
+                expect(ci.activities.items[0].object.inputs).to.not.be.null;
+              });
           }));
       });
 


### PR DESCRIPTION
# Pull Request Template

## Description

Conversation service for cardAction Activity has been updated to require parent activity. List of changes are:

- Added default activity object
- Added additional parameter(parentActivity)
- Assigned parentActivity Id and type to the cardAction Activity


## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Coverage

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Integration Test

**Test Configuration**:
* SDK Version
* Node/Browser Version
* NPM Version

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

@mattnorris 
