### PR TITLE
fix(media): find content mediaShare

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/locus-info/mediaSharesUtils.js
@@ -55,13 +55,8 @@ mediaSharesUtils.extractContent = (mediaShares) => {
   if (!mediaShares || !mediaShares.length) {
     return null;
   }
-  const supposed = mediaShares[0];
 
-  if (supposed && supposed.name === CONTENT) {
-    return supposed;
-  }
-
-  return null;
+  return mediaShares.find((share) => share.name === CONTENT) || null;
 };
 
 /**

--- a/packages/node_modules/@webex/plugin-meetings/src/members/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/members/index.js
@@ -4,12 +4,7 @@
 import {isEmpty} from 'lodash';
 import {StatelessSparkPlugin} from '@webex/webex-core';
 
-import {
-  MEETINGS,
-  EVENT_TRIGGERS,
-  FLOOR_ACTION,
-  CONTENT
-} from '../constants';
+import {MEETINGS, EVENT_TRIGGERS, FLOOR_ACTION, CONTENT} from '../constants';
 import Trigger from '../common/events/trigger-proxy';
 import Member from '../member';
 import LoggerProxy from '../common/logs/logger-proxy';
@@ -159,12 +154,14 @@ export default class Members extends StatelessSparkPlugin {
 
   locusMediaSharesUpdate(payload) {
     const currentContent = payload.current;
+    const previousContent = payload.previous;
     let whoSharing = null;
     let whoStopped = null;
 
     if (currentContent && currentContent.contentId) {
       if (currentContent.disposition === FLOOR_ACTION.GRANTED) {
         whoSharing = currentContent.contentId;
+        whoStopped = previousContent && previousContent.contentId;
       }
       else if (currentContent.disposition === FLOOR_ACTION.RELEASED) {
         whoStopped = currentContent.contentId;
@@ -309,7 +306,7 @@ export default class Members extends StatelessSparkPlugin {
       this.type = type;
     }
     else if (fullState) {
-      this.type = fullState && fullState.type || null;
+      this.type = (fullState && fullState.type) || null;
     }
     else {
       throw new Error('Setting type for the Members module should be done with a fullstate object or type string');
@@ -349,9 +346,16 @@ export default class Members extends StatelessSparkPlugin {
       this.mediaShareContentId = contentId;
     }
     else if (locus) {
-      this.mediaShareContentId = locus &&
-      locus.mediaShares && locus.mediaShares.length && locus.mediaShares[0] && locus.mediaShares[0].name === CONTENT &&
-      locus.mediaShares[0].floor && locus.mediaShares[0].floor.beneficiary ? locus.mediaShares[0].floor.beneficiary.id :
+      const contentMediaShare =
+        locus.mediaShares &&
+        locus.mediaShares.length &&
+        locus.mediaShares.find((mediaShare) => mediaShare.name === CONTENT);
+
+      this.mediaShareContentId =
+        (contentMediaShare &&
+          contentMediaShare.floor &&
+          contentMediaShare.floor.beneficiary &&
+          contentMediaShare.floor.beneficiary.id) ||
         null;
     }
     else {
@@ -380,20 +384,24 @@ export default class Members extends StatelessSparkPlugin {
         if (existing) {
           // TODO: compare existing member to new participant coming in properties and determine if updated (this helps for non delta events)
           // on client re renders, but we will have to determine what values to compare to determine difference, premature optimization
-          membersUpdate.updated.push(new Member(participant, {
-            selfId: this.selfId,
-            hostId: this.hostId,
-            contentSharingId: this.mediaShareContentId,
-            type: this.type
-          }));
+          membersUpdate.updated.push(
+            new Member(participant, {
+              selfId: this.selfId,
+              hostId: this.hostId,
+              contentSharingId: this.mediaShareContentId,
+              type: this.type
+            })
+          );
         }
         else {
-          membersUpdate.added.push(new Member(participant, {
-            selfId: this.selfId,
-            hostId: this.hostId,
-            contentSharingId: this.mediaShareContentId,
-            type: this.type
-          }));
+          membersUpdate.added.push(
+            new Member(participant, {
+              selfId: this.selfId,
+              hostId: this.hostId,
+              contentSharingId: this.mediaShareContentId,
+              type: this.type
+            })
+          );
         }
       });
     }
@@ -413,7 +421,9 @@ export default class Members extends StatelessSparkPlugin {
       return Promise.reject(new Error('The associated locus url for this meeting object must be defined.'));
     }
     if (MembersUtil.isInvalidInvitee(invitee)) {
-      return Promise.reject(new Error('The invitee must be defined with either a valid email, or emailAddress property.'));
+      return Promise.reject(
+        new Error('The invitee must be defined with either a valid email, or emailAddress property.')
+      );
     }
     const options = MembersUtil.generateAddMemberOptions(invitee, this.locusUrl, alertIfActive);
 


### PR DESCRIPTION
## Description
previously, when attempt to grab the "content" mediaShare, we assumed it was at the `[0]` index. the order of these mediaShares however is not guaranteed to have content at `[0]`, so instead of `[0]`
use `find`. this meant that when emitting a `MEMBERS_CONTENT_UPDATE` event, we were not correctly reporting who ended/started sharing.

## Type of Change
bug fix

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Test Coverage
Take over someone else's share. Check the payload from the `MEMBERS_CONTENT_UPDATE` event. instead of `null` values, it will have member ids as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
