### PR TITLE
fix(meetings): accept and pass options from meeting.leave

### DIFF
--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1717,8 +1717,8 @@ export default class Meeting extends StatelessSparkPlugin {
    * @public
    * @memberof Meeting
    */
-  leave() {
-    return MeetingUtil.leaveMeeting(this)
+  leave(options = {}) {
+    return MeetingUtil.leaveMeeting(this, options)
       .then((leave) => {
         this.meetingFSM.leave();
         if (this.wirelessShare || this.guest) {

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/index.js
@@ -1401,7 +1401,7 @@ export default class Meeting extends StatelessSparkPlugin {
    * @memberof Meeting
    */
   addMedia(options = {}) {
-    if (MeetingUtil.isGuestUnjoined(this.guest, this.locusInfo)) {
+    if (MeetingUtil.isGuestUnjoined(this.guest, this.locusInfo) && !this.wirelessShare) {
       return Promise.reject(new Error('To add media, the guest user must be admitted. Wait to be admitted to call addMedia'));
     }
     const {localStream, localShare, mediaSettings} = options;

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/request.js
@@ -62,8 +62,7 @@ export default class MeetingRequest extends StatelessSparkPlugin {
     if (locusUrl) {
       url = `${locusUrl}/${PARTICIPANT}`;
     }
-    else
-    if (sipUri) {
+    else if (sipUri) {
       // eslint-lin-disable-next-line no-warning-comments
       // TODO switch to use the locus object and look into federation?
       url = `${this.spark.internal.device.services.locusServiceUrl}/${LOCI}/${CALL}`;
@@ -71,7 +70,6 @@ export default class MeetingRequest extends StatelessSparkPlugin {
         address: sipUri
       };
     }
-
 
     // TODO: -- this will be resolved in SDK request
     url = url.concat(`?${ALTERNATE_REDIRECT_TRUE}`);
@@ -110,7 +108,7 @@ export default class MeetingRequest extends StatelessSparkPlugin {
     return this.request({
       method: HTTP_VERBS.GET,
       uri: syncUrl
-    })// TODO: Handle if delta sync failed . Get the full locus object
+    }) // TODO: Handle if delta sync failed . Get the full locus object
       .catch((err) => {
         LoggerProxy.logger.error(`MeetingRequest->syncMeeting#Error syncing meeting, error ${err}`);
 
@@ -138,12 +136,11 @@ export default class MeetingRequest extends StatelessSparkPlugin {
       return this.request({
         method: HTTP_VERBS.GET,
         uri: locusUrl
-      })
-        .catch((err) => {
-          LoggerProxy.logger.error(`MeetingRequest->getFullLocus#Error getting full locus, error ${err}`);
+      }).catch((err) => {
+        LoggerProxy.logger.error(`MeetingRequest->getFullLocus#Error getting full locus, error ${err}`);
 
-          return err;
-        });
+        return err;
+      });
     }
 
     return Promise.reject();

--- a/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
+++ b/packages/node_modules/@webex/plugin-meetings/src/meeting/util.js
@@ -2,12 +2,7 @@ import {isEmpty} from 'lodash';
 
 import Media from '../media';
 import LoggerProxy from '../common/logs/logger-proxy';
-import {
-  INTENT_TO_JOIN,
-  MODERATOR_TRUE,
-  MODERATOR_FALSE,
-  _JOINED_
-} from '../constants';
+import {INTENT_TO_JOIN, MODERATOR_TRUE, MODERATOR_FALSE, _JOINED_} from '../constants';
 import IntentToJoinError from '../common/errors/intent-to-join';
 import JoinMeetingError from '../common/errors/join-meeting';
 
@@ -43,13 +38,15 @@ MeetingUtil.remoteUpdateAudioVideo = (audioMuted, videoMuted, meeting) => {
     return Promise.reject(new Error('You need a media id on the meeting to change remote audio.'));
   }
 
-  return meeting.meetingRequest.remoteAudioVideoToggle({
-    locusUrl: meeting.locusUrl,
-    selfId: meeting.selfId,
-    localMedias,
-    deviceUrl: meeting.deviceUrl,
-    correlationId: meeting.correlationId
-  }).then((response) => meeting.locusInfo.onFullLocus(response.body.locus));
+  return meeting.meetingRequest
+    .remoteAudioVideoToggle({
+      locusUrl: meeting.locusUrl,
+      selfId: meeting.selfId,
+      localMedias,
+      deviceUrl: meeting.deviceUrl,
+      correlationId: meeting.correlationId
+    })
+    .then((response) => meeting.locusInfo.onFullLocus(response.body.locus));
 };
 
 MeetingUtil.checkShare = (meeting) => {
@@ -59,7 +56,6 @@ MeetingUtil.checkShare = (meeting) => {
 
   return Promise.resolve();
 };
-
 
 // TODO: have locus ignore hostPin if they find out it's my claimed PMR
 /*
@@ -118,27 +114,37 @@ MeetingUtil.joinMeeting = (meeting, options) => {
     .then((res) => MeetingUtil.parseLocusJoin(res));
 };
 
-MeetingUtil.cleanUp = (meeting) => meeting.closeLocalStream()
-  .then(() => meeting.closeLocalShare())
-  .then(() => meeting.closePeerConnections())
-  .then(() => {
-    console.log(`${meeting.name} CLEAN UP MEETING ==========================`);
-    meeting.unsetLocalVideoTrack();
-    meeting.unsetLocalShareTrack();
-    meeting.unsetRemoteStream();
-    meeting.unsetPeerConnections();
-  })
-  .then(() => meeting.roap.stop(meeting.correlationId, meeting.roapSeq));
-
-MeetingUtil.leaveMeeting = (meeting) =>
-  meeting.meetingRequest
-    .leaveMeeting({
-      locusUrl: meeting.locusUrl,
-      selfId: meeting.selfId,
-      correlationId: meeting.correlationId,
-      resourceId: meeting.resourceId || null,
-      deviceUrl: meeting.deviceUrl
+MeetingUtil.cleanUp = (meeting) =>
+  meeting
+    .closeLocalStream()
+    .then(() => meeting.closeLocalShare())
+    .then(() => meeting.closePeerConnections())
+    .then(() => {
+      console.log(`${meeting.name} CLEAN UP MEETING ==========================`);
+      meeting.unsetLocalVideoTrack();
+      meeting.unsetLocalShareTrack();
+      meeting.unsetRemoteStream();
+      meeting.unsetPeerConnections();
     })
+    .then(() => meeting.roap.stop(meeting.correlationId, meeting.roapSeq));
+
+// by default will leave on meeting's resourceId
+// if you explicity want it not to leave on resource id, pass
+// {resourceId: null}
+// TODO: chris, you can modify this however you want
+MeetingUtil.leaveMeeting = (meeting, options = {}) => {
+  const defaultOptions = {
+    locusUrl: meeting.locusUrl,
+    selfId: meeting.selfId,
+    correlationId: meeting.correlationId,
+    resourceId: meeting.resourceId,
+    deviceUrl: meeting.deviceUrl
+  };
+
+  const leaveOptions = {...defaultOptions, ...options};
+
+  return meeting.meetingRequest
+    .leaveMeeting(leaveOptions)
     .then((response) => {
       if (response && response.body && response.body.locus) {
         meeting.locusInfo.onFullLocus(response.body.locus);
@@ -147,19 +153,24 @@ MeetingUtil.leaveMeeting = (meeting) =>
       return MeetingUtil.cleanUp(meeting);
     })
     .catch((err) => {
-      LoggerProxy.logger.error(`MeetingUtil->leaveMeeting#An error occured while trying to leave meeting with an id of ${meeting.id}, error: ${err}`);
+      LoggerProxy.logger.error(
+        `MeetingUtil->leaveMeeting#An error occured while trying to leave meeting with an id of ${
+          meeting.id
+        }, error: ${err}`
+      );
 
       return Promise.reject(err);
     });
-
-MeetingUtil.declineMeeting = (meeting, reason) => meeting.meetingRequest
-  .declineMeeting({
+};
+MeetingUtil.declineMeeting = (meeting, reason) =>
+  meeting.meetingRequest.declineMeeting({
     locusUrl: meeting.locusUrl,
     deviceUrl: meeting.deviceUrl,
     reason
   });
 
-MeetingUtil.isGuestUnjoined = (guest, locusInfo) => guest && locusInfo.parsedLocus && locusInfo.parsedLocus.self && locusInfo.parsedLocus.self.state !== _JOINED_;
+MeetingUtil.isGuestUnjoined = (guest, locusInfo) =>
+  guest && locusInfo.parsedLocus && locusInfo.parsedLocus.self && locusInfo.parsedLocus.self.state !== _JOINED_;
 
 MeetingUtil.joinMeetingOptions = (meeting, options) => {
   meeting.resourceId = meeting.resourceId || options.resourceId;
@@ -194,7 +205,6 @@ MeetingUtil.joinMeetingOptions = (meeting, options) => {
       return Promise.reject(new JoinMeetingError(err, options));
     });
 };
-
 
 MeetingUtil.validateOptions = (options) => {
   const {

--- a/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/node_modules/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -38,8 +38,7 @@ skipInBrowser(describe)('plugin-meetings', () => {
     LoggerConfig.set({verboseEvents: true, enable: false});
     LoggerProxy.set(logger);
     TriggerProxy.trigger = sinon.stub().returns(true);
-    MediaUtil.createPeerConnection = sinon.stub().returns({
-    });
+    MediaUtil.createPeerConnection = sinon.stub().returns({});
   });
   describe('meeting index', () => {
     let meeting;
@@ -495,6 +494,32 @@ skipInBrowser(describe)('plugin-meetings', () => {
           assert.calledOnce(meeting.unsetPeerConnections);
           assert.calledOnce(meeting.roap.stop);
         });
+        it('should leave the meeting without leaving resource', async () => {
+          const leave = meeting.leave({resourceId: null});
+
+          assert.exists(leave.then);
+          await leave;
+          assert.calledWith(meeting.meetingRequest.leaveMeeting, {
+            locusUrl: meeting.locusUrl,
+            correlationId: meeting.correlationId,
+            selfId: meeting.selfId,
+            resourceId: null,
+            deviceUrl: meeting.deviceUrl
+          });
+        });
+        it('should leave the meeting on the resource', async () => {
+          const leave = meeting.leave();
+
+          assert.exists(leave.then);
+          await leave;
+          assert.calledWith(meeting.meetingRequest.leaveMeeting, {
+            locusUrl: meeting.locusUrl,
+            correlationId: meeting.correlationId,
+            selfId: meeting.selfId,
+            resourceId: meeting.resourceId,
+            deviceUrl: meeting.deviceUrl
+          });
+        });
       });
       describe('#share', () => {
         it('should have #share', () => {
@@ -546,7 +571,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
             assert.exists(reconnect.then);
             await reconnect;
             assert.calledOnce(TriggerProxy.trigger);
-            assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'reconnect'}, 'meeting:reconnectionSuccess', {reconnect: test1});
+            assert.calledWith(
+              TriggerProxy.trigger,
+              sinon.match.instanceOf(Meeting),
+              {file: 'meeting/index', function: 'reconnect'},
+              'meeting:reconnectionSuccess',
+              {reconnect: test1}
+            );
             assert.calledOnce(meeting.reconnectionManager.reset);
           });
         });
@@ -557,7 +588,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
             meeting.reconnectionManager.reset = sinon.stub().returns(true);
             await meeting.reconnect().catch(() => {
               assert.calledOnce(TriggerProxy.trigger);
-              assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'reconnect'}, 'meeting:reconnectionFailure', {error: sinon.match.any});
+              assert.calledWith(
+                TriggerProxy.trigger,
+                sinon.match.instanceOf(Meeting),
+                {file: 'meeting/index', function: 'reconnect'},
+                'meeting:reconnectionFailure',
+                {error: sinon.match.any}
+              );
               assert.calledOnce(meeting.reconnectionManager.reset);
             });
           });
@@ -568,7 +605,12 @@ skipInBrowser(describe)('plugin-meetings', () => {
           Media.stopStream = sinon.stub().returns(Promise.resolve());
           await meeting.closeRemoteStream();
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'closeRemoteStream'}, 'media:stopped');
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'closeRemoteStream'},
+            'media:stopped'
+          );
           assert.notOk(meeting.mediaProperties.shareStream);
         });
       });
@@ -577,7 +619,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
           Media.stopStream = sinon.stub().returns(Promise.resolve());
           await meeting.closeLocalShare();
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'closeLocalShare'}, 'media:stopped', {type: 'localShare'});
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'closeLocalShare'},
+            'media:stopped',
+            {type: 'localShare'}
+          );
         });
       });
       describe('#closeLocalStream', () => {
@@ -585,7 +633,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
           Media.stopStream = sinon.stub().returns(Promise.resolve());
           await meeting.closeLocalStream();
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'closeLocalStream'}, 'media:stopped', {type: 'local'});
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'closeLocalStream'},
+            'media:stopped',
+            {type: 'local'}
+          );
         });
       });
       describe('#setLocalShareTrack', () => {
@@ -599,7 +653,12 @@ skipInBrowser(describe)('plugin-meetings', () => {
           meeting.stopShare = sinon.stub().returns(true);
           meeting.setLocalShareTrack(test1);
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'setLocalShareTrack'}, 'media:ready');
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'setLocalShareTrack'},
+            'media:ready'
+          );
           assert.calledOnce(meeting.mediaProperties.setLocalShareTrack);
           assert.equal(meeting.mediaProperties.localStream, undefined);
           meeting.mediaProperties.shareTrack.onended();
@@ -613,7 +672,13 @@ skipInBrowser(describe)('plugin-meetings', () => {
           meeting.setShareStream(pc);
           pc.ontrack({streams: [test1]});
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'setShareStream:pc.ontrack'}, 'media:ready', {type: 'remoteShare', stream: test1});
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'setShareStream:pc.ontrack'},
+            'media:ready',
+            {type: 'remoteShare', stream: test1}
+          );
           assert.equal(meeting.mediaProperties.remoteShare, test1);
         });
       });
@@ -640,13 +705,25 @@ skipInBrowser(describe)('plugin-meetings', () => {
         it('listens to the self unadmitted guest event', (done) => {
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_UNADMITTED_GUEST', test1);
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'setUpLocusInfoSelfListener'}, 'meeting:self:lobbyWaiting', {payload: test1});
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'setUpLocusInfoSelfListener'},
+            'meeting:self:lobbyWaiting',
+            {payload: test1}
+          );
           done();
         });
         it('listens to the self admitted guest event', (done) => {
           meeting.locusInfo.emit({function: 'test', file: 'test'}, 'SELF_ADMITTED_GUEST', test1);
           assert.calledOnce(TriggerProxy.trigger);
-          assert.calledWith(TriggerProxy.trigger, sinon.match.instanceOf(Meeting), {file: 'meeting/index', function: 'setUpLocusInfoSelfListener'}, 'meeting:self:guestAdmitted', {payload: test1});
+          assert.calledWith(
+            TriggerProxy.trigger,
+            sinon.match.instanceOf(Meeting),
+            {file: 'meeting/index', function: 'setUpLocusInfoSelfListener'},
+            'meeting:self:guestAdmitted',
+            {payload: test1}
+          );
           done();
         });
       });


### PR DESCRIPTION
## Description
`leave` method in `packages/node_modules/@webex/plugin-meetings/src/meeting/index.js` now accepts an options argument and passes further down to util/request. the user can now specifiy what resourceId, correlationId, locusUrl, etc they wish to leave on.

## Type of Change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
